### PR TITLE
User data bug fixes.

### DIFF
--- a/app/(routes)/(auth)/login/_components/LoginPage.tsx
+++ b/app/(routes)/(auth)/login/_components/LoginPage.tsx
@@ -8,8 +8,8 @@ import { useRouter } from "next/navigation";
 import React, { useContext, useEffect } from "react";
 
 type LoginFormState = {
-  email: string;
-  password: string;
+  user_email: string;
+  user_password: string;
 };
 
 const LoginPage: React.FC = () => {
@@ -18,8 +18,8 @@ const LoginPage: React.FC = () => {
   const { logIn, user } = useContext(AuthContext);
 
   const [form, setForm] = React.useState<LoginFormState>({
-    email: "",
-    password: "",
+    user_email: "",
+    user_password: "",
   });
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -40,18 +40,18 @@ const LoginPage: React.FC = () => {
 
     setSuccess(null);
 
-    if (!form.email.trim()) {
+    if (!form.user_email.trim()) {
       setError("Email is required.");
       return;
     }
 
-    if (form.password.length < 8) {
+    if (form.user_password.length < 8) {
       setError("Password must be at least 8 characters long.");
       return;
     }
 
     setIsSubmitting(true);
-    const response = await logIn({ email: form.email.trim(), password: form.password });
+    const response = await logIn({ email: form.user_email.trim(), password: form.user_password });
     if (response === null) {
       setSuccess("Login successful! Redirecting...");
       router.push('/dashboard');
@@ -86,8 +86,8 @@ const LoginPage: React.FC = () => {
                 required
                 sizeOptions={{ height: 24 }}
                 className="w-full"
-                value={form.email}
-                onChange={updateField("email")}
+                value={form.user_email}
+                onChange={updateField("user_email")}
               />
             </div>
 
@@ -101,8 +101,8 @@ const LoginPage: React.FC = () => {
                 required
                 sizeOptions={{ height: 24 }}
                 className="w-full"
-                value={form.password}
-                onChange={updateField("password")}
+                value={form.user_password}
+                onChange={updateField("user_password")}
               />
             </div>
 

--- a/app/(routes)/(auth)/register/_components/RegisterPage.tsx
+++ b/app/(routes)/(auth)/register/_components/RegisterPage.tsx
@@ -8,26 +8,26 @@ import { useRouter } from "next/navigation";
 import React from "react";
 
 type RegisterFormState = {
-  firstName: string;
-  lastName: string;
-  email: string;
-  phoneNumber: string;
-  dateOfBirth: string;
-  password: string;
-  confirmPassword: string;
+  user_firstname: string;
+  user_lastname: string;
+  user_email: string;
+  user_phone_number: string;
+  user_dob: string;
+  user_password: string;
+  confirm_password: string;
 };
 
 const RegisterPage: React.FC = () => {
   const router = useRouter();
 
   const [form, setForm] = React.useState<RegisterFormState>({
-    firstName: "",
-    lastName: "",
-    email: "",
-    phoneNumber: "",
-    dateOfBirth: "",
-    password: "",
-    confirmPassword: "",
+    user_firstname: "",
+    user_lastname: "",
+    user_email: "",
+    user_phone_number: "",
+    user_dob: "",
+    user_password: "",
+    confirm_password: "",
   });
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -44,7 +44,7 @@ const RegisterPage: React.FC = () => {
 
     setSuccess(null);
 
-    const { data: exists, error } = await supabase.rpc("email_exists", { email_to_check: form.email.trim() });
+    const { data: exists, error } = await supabase.rpc("email_exists", { email_to_check: form.user_email.trim() });
 
     if (error) {
       setError("An error occurred while checking the email: " + error.message);
@@ -56,28 +56,28 @@ const RegisterPage: React.FC = () => {
       return;
     }
 
-    if (form.password.length < 8) {
+    if (form.user_password.length < 8) {
       setError("Password must be at least 8 characters long.");
       return;
     }
 
-    if (form.password !== form.confirmPassword) {
+    if (form.user_password !== form.confirm_password) {
       setError("Passwords do not match.");
       return;
     }
 
     setIsSubmitting(true);
-    try {
 
+    try {
       const { data, error: signUpError } = await supabase.auth.signUp({
-        email: form.email.trim(),
-        password: form.password,
+        email: form.user_email.trim(),
+        password: form.user_password,
         options: {
           data: {
-            firstName: form.firstName.trim(),
-            lastName: form.lastName.trim(),
-            phoneNumber: form.phoneNumber.trim(),
-            dateOfBirth: form.dateOfBirth,
+            user_firstname: form.user_firstname.trim(),
+            user_lastname: form.user_lastname.trim(),
+            user_phone_number: form.user_phone_number.trim(),
+            user_dob: form.user_dob.trim(),
           },
         },
       });
@@ -121,8 +121,8 @@ const RegisterPage: React.FC = () => {
                 required
                 sizeOptions={{ height: 24 }}
                 className="w-full"
-                value={form.firstName}
-                onChange={updateField("firstName")}
+                value={form.user_firstname}
+                onChange={updateField("user_firstname")}
               />
             </div>
 
@@ -135,8 +135,8 @@ const RegisterPage: React.FC = () => {
                 required
                 sizeOptions={{ height: 24 }}
                 className="w-full"
-                value={form.lastName}
-                onChange={updateField("lastName")}
+                value={form.user_lastname}
+                onChange={updateField("user_lastname")}
               />
             </div>
 
@@ -150,9 +150,9 @@ const RegisterPage: React.FC = () => {
                 required
                 sizeOptions={{ height: 24 }}
                 className="w-full"
-                value={form.email}
-                onChange={updateField("email")}
-                onBlur={() => setForm((prev) => ({ ...prev, email: form.email.trim().toLowerCase() }))}
+                value={form.user_email}
+                onChange={updateField("user_email")}
+                onBlur={() => setForm((prev) => ({ ...prev, user_email: form.user_email.trim().toLowerCase() }))}
               />
             </div>
 
@@ -165,8 +165,8 @@ const RegisterPage: React.FC = () => {
                 autoComplete="tel"
                 sizeOptions={{ height: 24 }}
                 className="w-full"
-                value={form.phoneNumber}
-                onChange={updateField("phoneNumber")}
+                value={form.user_phone_number}
+                onChange={updateField("user_phone_number")}
               />
             </div>
 
@@ -180,8 +180,8 @@ const RegisterPage: React.FC = () => {
                 required
                 sizeOptions={{ height: 24 }}
                 className="w-full"
-                value={form.dateOfBirth}
-                onChange={updateField("dateOfBirth")}
+                value={form.user_dob}
+                onChange={updateField("user_dob")}
               />
             </div>
 
@@ -195,8 +195,8 @@ const RegisterPage: React.FC = () => {
                 required
                 sizeOptions={{ height: 24 }}
                 className="w-full"
-                value={form.password}
-                onChange={updateField("password")}
+                value={form.user_password}
+                onChange={updateField("user_password")}
               />
             </div>
 
@@ -210,8 +210,8 @@ const RegisterPage: React.FC = () => {
                 required
                 sizeOptions={{ height: 24 }}
                 className="w-full"
-                value={form.confirmPassword}
-                onChange={updateField("confirmPassword")}
+                value={form.confirm_password}
+                onChange={updateField("confirm_password")}
               />
             </div>
 

--- a/app/(routes)/(auth)/register/_components/RegisterPage.tsx
+++ b/app/(routes)/(auth)/register/_components/RegisterPage.tsx
@@ -73,7 +73,7 @@ const RegisterPage: React.FC = () => {
 
     try {
       const error = await signUp({
-        email: form.user_email.trim(),
+        email: form.user_email.trim().toLowerCase(),
         password: form.user_password,
         user_firstname: form.user_firstname.trim(),
         user_lastname: form.user_lastname.trim(),

--- a/app/(routes)/(auth)/register/_components/RegisterPage.tsx
+++ b/app/(routes)/(auth)/register/_components/RegisterPage.tsx
@@ -3,9 +3,10 @@
 import UsButton from "@/app/_common/ui/buttons/UsButton";
 import UsInput from "@/app/_common/ui/inputs/UsInput";
 import UsWidget from "@/app/_common/ui/other/UsWidget";
+import AuthContext from "@/app/_context/auth/AuthContext";
 import { supabase } from "@/lib/supabase";
 import { useRouter } from "next/navigation";
-import React from "react";
+import React, { useContext } from "react";
 
 type RegisterFormState = {
   user_firstname: string;
@@ -19,6 +20,8 @@ type RegisterFormState = {
 
 const RegisterPage: React.FC = () => {
   const router = useRouter();
+
+  const { signUp } = useContext(AuthContext);
 
   const [form, setForm] = React.useState<RegisterFormState>({
     user_firstname: "",
@@ -69,21 +72,18 @@ const RegisterPage: React.FC = () => {
     setIsSubmitting(true);
 
     try {
-      const { data, error: signUpError } = await supabase.auth.signUp({
+      const error = await signUp({
         email: form.user_email.trim(),
         password: form.user_password,
-        options: {
-          data: {
-            user_firstname: form.user_firstname.trim(),
-            user_lastname: form.user_lastname.trim(),
-            user_phone_number: form.user_phone_number.trim(),
-            user_dob: form.user_dob.trim(),
-          },
-        },
+        user_firstname: form.user_firstname.trim(),
+        user_lastname: form.user_lastname.trim(),
+        user_phone_number: form.user_phone_number.trim(),
+        user_dob: form.user_dob.trim(),
       });
 
-      if (signUpError) {
-        setError("Registration failed: " + signUpError.message);
+
+      if (error) {
+        setError("Registration failed: " + error);
         return;
       }
 

--- a/app/(routes)/dashboard/_components/DashboardPage.tsx
+++ b/app/(routes)/dashboard/_components/DashboardPage.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 const DashboardPage = () => {
   const router = useRouter();
   return (
-    <div className="flex w-full flex-col items-center py-10 font-bold text-3xl text-center">     
+    <div className="flex w-full flex-col items-center py-10 font-bold text-3xl text-center">
       <h1 className="mb-8 text-4xl">{'{Active Tournaments}'}</h1>
       <div className="flex flex-col border-2 border-black p-12">
         <h2 className="mb-6">{'{tournament name}'}</h2>

--- a/app/_common/layout/AppLayout.tsx
+++ b/app/_common/layout/AppLayout.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import React from "react";
+import React, { useContext } from "react";
 import UsHeader from "./header/UsHeader";
 import UsFooter from "./UsFooter";
+import AuthContext from "@/app/_context/auth/AuthContext";
+import { Spinner } from "@/components/ui/spinner";
 
 type Props = {
   children?: React.ReactNode;
@@ -15,16 +17,26 @@ const AppLayout: React.FC<Props> = ({
   showHeader = true,
   showFooter = true,
 }) => {
+  const { isLoading } = useContext(AuthContext);
+
   return (
     <div className="h-dvh flex flex-col overflow-hidden">
 
-      {showHeader && <UsHeader />}
+      {isLoading ? (
+        <div className="flex-1 flex items-center justify-center">
+          <Spinner className="size-8" />
+        </div>
+      ) : (
+        <>
+          {showHeader && <UsHeader />}
 
-      <main className="flex-1 min-h-0 overflow-y-auto p-4">
-        {children}
-      </main>
+          <main className="flex-1 min-h-0 overflow-y-auto p-4">
+            {children}
+          </main>
 
-      {showFooter && <UsFooter />}
+          {showFooter && <UsFooter />}
+        </>
+      )}
 
     </div>
   );

--- a/app/_context/auth/AuthContext.tsx
+++ b/app/_context/auth/AuthContext.tsx
@@ -6,6 +6,7 @@ import { LogInData } from "./AuthState";
 
 export type AuthContextType = {
   user: User | null;
+  isLoading: boolean;
   logIn: (logInData: LogInData) => Promise<null | string>;
   logOut: () => Promise<null | string>;
 };

--- a/app/_context/auth/AuthContext.tsx
+++ b/app/_context/auth/AuthContext.tsx
@@ -2,11 +2,12 @@
 
 import { createContext } from "react";
 import type { User } from "@/app/_types/model/User";
-import { LogInData } from "./AuthState";
+import { LogInData, SignUpData } from "./AuthState";
 
 export type AuthContextType = {
   user: User | null;
   isLoading: boolean;
+  signUp: (signUpData: SignUpData) => Promise<null | string>;
   logIn: (logInData: LogInData) => Promise<null | string>;
   logOut: () => Promise<null | string>;
 };

--- a/app/_context/auth/AuthReducer.tsx
+++ b/app/_context/auth/AuthReducer.tsx
@@ -4,10 +4,12 @@ import { Reducer } from "react";
 
 export interface AuthReducerState {
   user: User | null;
+  isLoading: boolean;
 }
 
 export type AuthReducerAction =
-  | { type: AuthActionKind.SET_USER; payload: User | null };
+  | { type: AuthActionKind.SET_USER; payload: User | null }
+  | { type: AuthActionKind.SET_LOADING; payload: boolean };
 
 const authReducer: Reducer<AuthReducerState, AuthReducerAction> = (state, action): AuthReducerState => {
   switch (action.type) {
@@ -15,6 +17,12 @@ const authReducer: Reducer<AuthReducerState, AuthReducerAction> = (state, action
       return {
         ...state,
         user: action.payload,
+      };
+
+    case AuthActionKind.SET_LOADING:
+      return {
+        ...state,
+        isLoading: action.payload,
       };
 
     default:

--- a/app/_context/auth/AuthState.tsx
+++ b/app/_context/auth/AuthState.tsx
@@ -131,7 +131,11 @@ const AuthState = ({ children }: Props) => {
         .eq('user_id', data.user.id)
         .single();
 
-      if (profileError) return "Could not fetch user profile.";
+      if (profileError) {
+        await supabase.auth.signOut();
+        dispatch({ type: AuthActionKind.SET_USER, payload: null });
+        return "Could not fetch user profile.";
+      }
 
       dispatch({
         type: AuthActionKind.SET_USER,

--- a/app/_context/auth/AuthState.tsx
+++ b/app/_context/auth/AuthState.tsx
@@ -70,9 +70,25 @@ const AuthState = ({ children }: Props) => {
     };
     hydrate();
 
-    const { data: authListener } = supabase.auth.onAuthStateChange((event) => {
+    const { data: authListener } = supabase.auth.onAuthStateChange(async (event, session) => {
       if (event === "SIGNED_OUT") {
         dispatch({ type: AuthActionKind.SET_USER, payload: null });
+      } else if (
+        event === "SIGNED_IN" ||
+        event === "TOKEN_REFRESHED" ||
+        event === "USER_UPDATED"
+      ) {
+        if (session?.user) {
+          const { data: user, error } = await supabase
+            .from("user")
+            .select("*")
+            .eq("user_id", session.user.id)
+            .single();
+
+          if (error) console.error("Error fetching user profile on auth state change:", error);
+
+          if (user && mounted) dispatch({ type: AuthActionKind.SET_USER, payload: mapToAppUser(user) });
+        }
       }
     });
 

--- a/app/_context/auth/AuthState.tsx
+++ b/app/_context/auth/AuthState.tsx
@@ -12,6 +12,15 @@ export type LogInData = {
   password: string;
 };
 
+export type SignUpData = {
+  email: string;
+  password: string;
+  user_firstname: string;
+  user_lastname: string;
+  user_phone_number: string;
+  user_dob: string;
+};
+
 type Props = {
   children?: React.ReactNode | React.ReactNode[];
 }
@@ -73,6 +82,41 @@ const AuthState = ({ children }: Props) => {
     };
   }, []);
 
+  const signUp = async (signUpData: SignUpData) => {
+    try {
+      const { data, error: signUpError } = await supabase.auth.signUp({
+        email: signUpData.email.trim(),
+        password: signUpData.password,
+        options: {
+          data: {
+            user_firstname: signUpData.user_firstname.trim(),
+            user_lastname: signUpData.user_lastname.trim(),
+            user_phone_number: signUpData.user_phone_number.trim(),
+            user_dob: signUpData.user_dob.trim(),
+          },
+        },
+      });
+
+      if (signUpError) return signUpError.message;
+
+      const { data: user, error: profileError } = await supabase
+        .from("user")
+        .select("*")
+        .eq("user_id", data.user?.id)
+        .single();
+
+      if (profileError) return "Could not fetch user profile after sign up.";
+
+      dispatch({
+        type: AuthActionKind.SET_USER,
+        payload: mapToAppUser(user),
+      });
+      return null;
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  };
+
   const logIn = async (logInData: LogInData) => {
     try {
       const { data, error: signInError } = await supabase.auth.signInWithPassword(logInData);
@@ -113,6 +157,7 @@ const AuthState = ({ children }: Props) => {
       value={{
         user: state.user,
         isLoading: state.isLoading,
+        signUp,
         logIn,
         logOut,
       }}

--- a/app/_context/auth/AuthState.tsx
+++ b/app/_context/auth/AuthState.tsx
@@ -24,6 +24,19 @@ const AuthState = ({ children }: Props) => {
 
   const [state, dispatch] = useReducer(authReducer, initialState);
 
+  const mapToAppUser = (u: any): User => {
+    return new User(
+      u.user_id,
+      u.user_firstname,
+      u.user_lastname,
+      u.user_email,
+      u.user_phone_number,
+      u.user_dob ? new Date(u.user_dob) : null,
+      u.user_created_at ? new Date(u.user_created_at) : new Date(),
+      u.user_role
+    );
+  };
+
   useEffect(() => {
     let mounted = true;
 
@@ -40,7 +53,7 @@ const AuthState = ({ children }: Props) => {
 
           if (error) console.log("Error fetching user profile during hydration:", error);
 
-          if (user) dispatch({ type: AuthActionKind.SET_USER, payload: user });
+          if (user) dispatch({ type: AuthActionKind.SET_USER, payload: mapToAppUser(user) });
         }
       } finally {
         if (mounted) dispatch({ type: AuthActionKind.SET_LOADING, payload: false });
@@ -75,7 +88,7 @@ const AuthState = ({ children }: Props) => {
 
       dispatch({
         type: AuthActionKind.SET_USER,
-        payload: user,
+        payload: mapToAppUser(user),
       });
       return null;
     } catch (err) {

--- a/app/_context/auth/AuthState.tsx
+++ b/app/_context/auth/AuthState.tsx
@@ -19,6 +19,7 @@ type Props = {
 const AuthState = ({ children }: Props) => {
   const initialState: AuthReducerState = {
     user: null,
+    isLoading: true,
   };
 
   const [state, dispatch] = useReducer(authReducer, initialState);
@@ -26,71 +27,57 @@ const AuthState = ({ children }: Props) => {
   useEffect(() => {
     let mounted = true;
 
-    const mapToAppUser = (rawUser: any): User | null => {
-      if (!rawUser) return null;
-      const meta = rawUser.user_metadata ?? {};
-      return new User(
-        rawUser.id ?? meta.sub ?? "",
-        meta.firstName ?? "",
-        meta.lastName ?? "",
-        rawUser.email ?? meta.email ?? "",
-        meta.phoneNumber ?? "",
-        meta.dateOfBirth ? new Date(meta.dateOfBirth) : new Date(),
-        rawUser.created_at ? new Date(rawUser.created_at) : new Date()
-      );
-    };
-
     const hydrate = async () => {
-      const { data } = await supabase.auth.getUser();
-      if (!mounted) return;
-      const appUser = mapToAppUser(data.user);
-      dispatch({ type: AuthActionKind.SET_USER, payload: appUser });
+      try {
+        const { data: { user: authUser } } = await supabase.auth.getUser();
+
+        if (authUser && mounted) {
+          const { data: user, error } = await supabase
+            .from("user")
+            .select("*")
+            .eq("user_id", authUser.id)
+            .single();
+
+          if (error) console.log("Error fetching user profile during hydration:", error);
+
+          if (user) dispatch({ type: AuthActionKind.SET_USER, payload: user });
+        }
+      } finally {
+        if (mounted) dispatch({ type: AuthActionKind.SET_LOADING, payload: false });
+      }
     };
     hydrate();
 
-    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
-      const appUser = mapToAppUser(session?.user ?? null);
-      dispatch({ type: AuthActionKind.SET_USER, payload: appUser });
+    const { data: authListener } = supabase.auth.onAuthStateChange((event) => {
+      if (event === "SIGNED_OUT") {
+        dispatch({ type: AuthActionKind.SET_USER, payload: null });
+      }
     });
 
     return () => {
       mounted = false;
-      sub.subscription.unsubscribe();
+      authListener.subscription.unsubscribe();
     };
   }, []);
 
   const logIn = async (logInData: LogInData) => {
     try {
       const { data, error: signInError } = await supabase.auth.signInWithPassword(logInData);
+      if (signInError) return signInError.message;
 
-      if (signInError) return signInError.message ?? String(signInError);
+      const { data: user, error: profileError } = await supabase
+        .from('user')
+        .select('*')
+        .eq('user_id', data.user.id)
+        .single();
 
-      const { created_at } = data.user;
-      const {
-        sub,
-        firstName,
-        lastName,
-        email,
-        phoneNumber,
-        dateOfBirth,
-      } = data.user.user_metadata as any;
-
-      const user = new User(
-        sub ?? "",
-        firstName ?? "",
-        lastName ?? "",
-        email ?? "",
-        phoneNumber ?? "",
-        dateOfBirth ? new Date(dateOfBirth) : new Date(),
-        created_at ? new Date(created_at) : new Date()
-      );
+      if (profileError) return "Could not fetch user profile.";
 
       dispatch({
         type: AuthActionKind.SET_USER,
         payload: user,
       });
       return null;
-
     } catch (err) {
       return err instanceof Error ? err.message : String(err);
     }
@@ -112,6 +99,7 @@ const AuthState = ({ children }: Props) => {
     <AuthContext.Provider
       value={{
         user: state.user,
+        isLoading: state.isLoading,
         logIn,
         logOut,
       }}

--- a/app/_context/auth/AuthState.tsx
+++ b/app/_context/auth/AuthState.tsx
@@ -105,8 +105,11 @@ const AuthState = ({ children }: Props) => {
         .eq("user_id", data.user?.id)
         .single();
 
-      if (profileError) return "Could not fetch user profile after sign up.";
-
+      if (profileError) {
+        await supabase.auth.signOut();
+        dispatch({ type: AuthActionKind.SET_USER, payload: null });
+        return "Could not fetch user profile.";
+      }
       dispatch({
         type: AuthActionKind.SET_USER,
         payload: mapToAppUser(user),

--- a/app/_context/auth/AuthState.tsx
+++ b/app/_context/auth/AuthState.tsx
@@ -70,7 +70,7 @@ const AuthState = ({ children }: Props) => {
     };
     hydrate();
 
-    const { data: authListener } = supabase.auth.onAuthStateChange(async (event, session) => {
+    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === "SIGNED_OUT") {
         dispatch({ type: AuthActionKind.SET_USER, payload: null });
       } else if (
@@ -79,15 +79,22 @@ const AuthState = ({ children }: Props) => {
         event === "USER_UPDATED"
       ) {
         if (session?.user) {
-          const { data: user, error } = await supabase
-            .from("user")
-            .select("*")
-            .eq("user_id", session.user.id)
-            .single();
+          // Defer the DB call with setTimeout to avoid a deadlock with Supabase's
+          // internal auth lock (initializePromise). Calling supabase methods directly
+          // inside onAuthStateChange blocks the lock and prevents hydrate() from
+          // completing, keeping isLoading stuck at true.
+          const userId = session.user.id;
+          setTimeout(async () => {
+            const { data: user, error } = await supabase
+              .from("user")
+              .select("*")
+              .eq("user_id", userId)
+              .single();
 
-          if (error) console.error("Error fetching user profile on auth state change:", error);
+            if (error) console.error("Error fetching user profile on auth state change:", error);
 
-          if (user && mounted) dispatch({ type: AuthActionKind.SET_USER, payload: mapToAppUser(user) });
+            if (user && mounted) dispatch({ type: AuthActionKind.SET_USER, payload: mapToAppUser(user) });
+          }, 0);
         }
       }
     });

--- a/app/_types/context/index.ts
+++ b/app/_types/context/index.ts
@@ -1,3 +1,4 @@
 export enum AuthActionKind {
   SET_USER = "SET_USER",
+  SET_LOADING = "SET_LOADING",
 };

--- a/app/_types/model/User.ts
+++ b/app/_types/model/User.ts
@@ -1,7 +1,7 @@
 export class User {
   user_id: string;
   user_firstname: string;
-  user_lastname: string
+  user_lastname: string;
   user_email: string;
   user_phone_number: string;
   user_dob: Date | null;

--- a/app/_types/model/User.ts
+++ b/app/_types/model/User.ts
@@ -3,25 +3,28 @@ export class User {
   user_firstname: string;
   user_lastname: string
   user_email: string;
-  user_phonenumber: string;
-  user_dob: Date;
-  user_createdat: Date;
+  user_phone_number: string;
+  user_dob: Date | null;
+  user_created_at: Date;
+  user_role: string;
 
   constructor(
     id: string = "",
     firstname: string = "",
     lastname: string = "",
     email: string = "",
-    phonenumber: string = "",
-    dob: Date = new Date(),
-    createdat: Date = new Date()
+    phone_number: string = "",
+    dob: Date | null = null,
+    created_at: Date = new Date(),
+    role: string = "user"
   ) {
     this.user_id = id;
     this.user_firstname = firstname;
     this.user_lastname = lastname;
     this.user_email = email;
-    this.user_phonenumber = phonenumber;
+    this.user_phone_number = phone_number;
     this.user_dob = dob;
-    this.user_createdat = createdat;
+    this.user_created_at = created_at;
+    this.user_role = role;
   }
 }

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,0 +1,10 @@
+import { cn } from "@/lib/utils"
+import { Loader2Icon } from "lucide-react"
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon role="status" aria-label="Loading" className={cn("size-4 animate-spin", className)} {...props} />
+  )
+}
+
+export { Spinner }

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils"
 import { Loader2Icon } from "lucide-react"
+import React from "react"
 
 function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
   return (


### PR DESCRIPTION
- [x] Diagnosed root cause: async `onAuthStateChange` callback calling `supabase.from()` deadlocks Supabase's internal `initializePromise`, which blocks `hydrate()`'s `getUser()` → `isLoading` never becomes `false`
- [x] Fix: make the listener callback non-async; use `setTimeout(() => ..., 0)` to defer DB calls outside the auth lock; single `mounted` check before dispatch
- [x] CodeQL scan — no alerts

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).
