### PR TITLE
122 b107   patching the stage 2 tournament bugs to ensure brackets function correctly

### DIFF
--- a/app/(routes)/(auth)/profile/_components/ProfileBookCard.tsx
+++ b/app/(routes)/(auth)/profile/_components/ProfileBookCard.tsx
@@ -145,6 +145,36 @@ const ManageCard: React.FC<{ concept: Concept; className?: string; coverUrl: str
     }
   };
 
+  const handleReApply = async (submissionId: string) => {
+    if (pendingAction) return;
+    const actionKey = `reapply-${submissionId}`;
+    setPendingAction(actionKey);
+    try {
+      const { error } = await supabase
+        .from("tournament_submission")
+        .update({ tournamentsub_status: "pending", tournamentsub_updated_at: new Date().toISOString() })
+        .eq("tournamentsub_id", submissionId);
+
+      if (error) {
+        alert(`Failed to re-apply: ${error.message}`);
+        return;
+      }
+
+      // refresh submissions list
+      const { data: sData } = await supabase
+        .from("tournament_submission")
+        .select("*")
+        .eq("concept_id", concept.concept_id)
+        .not("tournamentsub_status", "eq", "deleted");
+      setSubs(sData ?? []);
+    } catch (err) {
+      console.error(err);
+      alert("Failed to re-apply.");
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
   const handleDeleteConcept = async () => {
     if (pendingAction) return;
     const ok = window.confirm("Permanently delete this book concept? This cannot be undone.");
@@ -229,7 +259,13 @@ const ManageCard: React.FC<{ concept: Concept; className?: string; coverUrl: str
                 tournaments.map((t) => {
                   const submission = subs.find((s) => String(s.tournament_id) === String(t.tournament_id));
                   const submitted = !!submission;
-                  const submissionStatus = submission ? (submission.tournamentsub_status === 'approved' ? 'Approved' : 'Awaiting approval') : 'No submission';
+                  const submissionStatus = submission ? (
+                    submission.tournamentsub_status === 'approved'
+                      ? 'Approved'
+                      : submission.tournamentsub_status === 'rejected'
+                        ? 'Rejected'
+                        : 'Awaiting approval'
+                  ) : 'No submission';
                   return (
                     <div key={t.tournament_id} className="flex items-center justify-between gap-4 p-3 border rounded-md">
                       <div>
@@ -246,9 +282,16 @@ const ManageCard: React.FC<{ concept: Concept; className?: string; coverUrl: str
                           </Button>
                         )}
                         {t.tournament_status === 'stage1' && submitted && (
-                          <Button disabled={!!pendingAction} variant="destructive" onClick={() => handleRemove(submission.tournamentsub_id)}>
-                            {pendingAction === `remove-${submission.tournamentsub_id}` ? "Removing..." : "Remove from tournament"}
-                          </Button>
+                          <>
+                            {submission.tournamentsub_status === 'rejected' && (
+                              <Button disabled={!!pendingAction} onClick={() => handleReApply(submission.tournamentsub_id)}>
+                                {pendingAction === `reapply-${submission.tournamentsub_id}` ? "Re-applying..." : "Re-apply"}
+                              </Button>
+                            )}
+                            <Button disabled={!!pendingAction} variant="destructive" onClick={() => handleRemove(submission.tournamentsub_id)}>
+                              {pendingAction === `remove-${submission.tournamentsub_id}` ? "Removing..." : "Remove from tournament"}
+                            </Button>
+                          </>
                         )}
                       </div>
                     </div>

--- a/app/(routes)/(auth)/profile/_components/ProfileBookCard.tsx
+++ b/app/(routes)/(auth)/profile/_components/ProfileBookCard.tsx
@@ -61,6 +61,8 @@ const ManageCard: React.FC<{ concept: Concept; className?: string; coverUrl: str
           tournament_id,
           tournament_title,
           tournament_status,
+          tournament_user_limit,
+          tournament_submission(tournamentsub_status),
           bracket(bracket_round_number, bracket_status)
         `)
         .in("tournament_status", ["stage1", "stage2"])
@@ -276,11 +278,24 @@ const ManageCard: React.FC<{ concept: Concept; className?: string; coverUrl: str
                         {submissionStatus && <div className="text-sm">Submission: {submissionStatus}</div>}
                       </div>
                       <div className="flex items-center gap-2">
-                        {t.tournament_status === 'stage1' && !submitted && (
-                          <Button disabled={!!pendingAction} onClick={() => handleAdd(t.tournament_id)}>
-                            {pendingAction === `add-${t.tournament_id}` ? "Adding..." : "Add to tournament"}
-                          </Button>
-                        )}
+                        {t.tournament_status === 'stage1' && !submitted && (() => {
+                          const allSubs: { tournamentsub_status: string }[] = t.tournament_submission ?? [];
+                          const validCount = allSubs.filter(
+                            (s: { tournamentsub_status: string }) =>
+                              s.tournamentsub_status !== 'rejected' &&
+                              s.tournamentsub_status !== 'terminated' &&
+                              s.tournamentsub_status !== 'deleted'
+                          ).length;
+                          const limit = t.tournament_user_limit ?? 0;
+                          const isFull = limit > 0 && validCount >= limit;
+                          return isFull ? (
+                            <span className="text-sm font-semibold text-red-600">Tournament full</span>
+                          ) : (
+                            <Button disabled={!!pendingAction} onClick={() => handleAdd(t.tournament_id)}>
+                              {pendingAction === `add-${t.tournament_id}` ? "Adding..." : "Add to tournament"}
+                            </Button>
+                          );
+                        })()}
                         {t.tournament_status === 'stage1' && submitted && (
                           <>
                             {submission.tournamentsub_status === 'rejected' && (

--- a/app/(routes)/(auth)/profile/_components/ProfileBookCard.tsx
+++ b/app/(routes)/(auth)/profile/_components/ProfileBookCard.tsx
@@ -5,6 +5,7 @@ import { supabase } from "@/lib/supabase";
 import { useContext, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import BookContext from "@/app/_context/book/BookContext";
+import { formatStatusLabel } from "@/app/_utilities/tournamentLifecycle";
 import {
   Dialog,
   DialogContent,
@@ -56,7 +57,12 @@ const ManageCard: React.FC<{ concept: Concept; className?: string; coverUrl: str
     try {
       const { data: tData, error: tError } = await supabase
         .from("tournament")
-        .select("tournament_id, tournament_title, tournament_status")
+        .select(`
+          tournament_id,
+          tournament_title,
+          tournament_status,
+          bracket(bracket_round_number, bracket_status)
+        `)
         .in("tournament_status", ["stage1", "stage2"])
         .order("tournament_start_date", { ascending: false });
 
@@ -228,7 +234,9 @@ const ManageCard: React.FC<{ concept: Concept; className?: string; coverUrl: str
                     <div key={t.tournament_id} className="flex items-center justify-between gap-4 p-3 border rounded-md">
                       <div>
                         <div className="font-semibold">{t.tournament_title}</div>
-                        <div className="text-sm text-muted-foreground">Tournament Status: {t.tournament_status === "stage1" ? "Stage 1" : "Stage 2"}</div>
+                        <div className="text-sm text-muted-foreground text-opacity-80">
+                          Tournament Status: {formatStatusLabel(t.tournament_status, t.bracket?.find((b: any) => b.bracket_status === "active")?.bracket_round_number || t.bracket?.[0]?.bracket_round_number)}
+                        </div>
                         {submissionStatus && <div className="text-sm">Submission: {submissionStatus}</div>}
                       </div>
                       <div className="flex items-center gap-2">

--- a/app/(routes)/admin/tournaments/_components/AdminTournamentsPage.tsx
+++ b/app/(routes)/admin/tournaments/_components/AdminTournamentsPage.tsx
@@ -47,7 +47,7 @@ async function getTournaments(): Promise<Tournament[]> {
     .not("tournament_submission.tournamentsub_status", "eq", "terminated")
     .not("tournament_submission.tournamentsub_status", "eq", "rejected")
     .not("tournament_submission.tournamentsub_status", "eq", "deleted")
-    .order("tournament_start_date", { ascending: false });
+    .order("tournament_end_date", { ascending: false });
 
   if (error) throw new Error(error.message);
   return (data ?? []).map((row) => ({

--- a/app/(routes)/admin/tournaments/_components/AdminTournamentsPage.tsx
+++ b/app/(routes)/admin/tournaments/_components/AdminTournamentsPage.tsx
@@ -187,8 +187,13 @@ const AdminTournamentsPage = () => {
   const [terminatingId, setTerminatingId] = useState<string | null>(null);
   const [isTerminating, setIsTerminating] = useState(false);
 
-  const fetchData = useCallback(() => {
+  const fetchData = useCallback(async () => {
     setError(null);
+    try {
+      await supabase.rpc("run_tournament_cron");
+    } catch (e) {
+      console.warn("Cron update check failed:", e);
+    }
     getTournaments()
       .then(setTournaments)
       .catch((err: Error) => setError(err.message));

--- a/app/(routes)/bookbuilder/_components/BookBuilderPage.tsx
+++ b/app/(routes)/bookbuilder/_components/BookBuilderPage.tsx
@@ -128,7 +128,7 @@ const BookBuilderPage = () => {
             try {
               const { data: tRows, error: tError } = await supabase
                 .from("tournament")
-                .select("tournament_id, tournament_status")
+                .select("tournament_id, tournament_status, tournament_user_limit, tournament_submission(tournamentsub_status)")
                 .eq("tournament_id", tId)
                 .limit(1);
 
@@ -141,13 +141,26 @@ const BookBuilderPage = () => {
                 if (tournamentRow.tournament_status !== "stage1") {
                   warning = `The tournament is not accepting submissions (status: ${tournamentRow.tournament_status}). Your concept has been submitted but it has not been added to the tournament. You can manage your submissions on your profile page.`;
                 } else {
-                  const { error: submissionError } = await supabase
-                    .from("tournament_submission")
-                    .insert({ concept_id: data.concept_id, tournament_id: tId });
+                  // Check capacity: count valid (non-rejected, non-terminated, non-deleted) submissions
+                  const allSubs: { tournamentsub_status: string }[] = tournamentRow.tournament_submission ?? [];
+                  const validCount = allSubs.filter(
+                    (s: { tournamentsub_status: string }) =>
+                      s.tournamentsub_status !== 'rejected' &&
+                      s.tournamentsub_status !== 'terminated' &&
+                      s.tournamentsub_status !== 'deleted'
+                  ).length;
+                  const limit: number = tournamentRow.tournament_user_limit ?? 0;
+                  if (limit > 0 && validCount >= limit) {
+                    warning = `Your book was created successfully, but could not be added to the tournament because it is full (${validCount}/${limit} slots taken). You can try adding it to another tournament from your profile page.`;
+                  } else {
+                    const { error: submissionError } = await supabase
+                      .from("tournament_submission")
+                      .insert({ concept_id: data.concept_id, tournament_id: tId });
 
-                  if (submissionError) {
-                    console.log("Error adding tournament submission - ", submissionError.message, "Code", submissionError.code);
-                    warning = `Your concept has been submitted, but it has not been added to the tournament: ${submissionError.message}`;
+                    if (submissionError) {
+                      console.log("Error adding tournament submission - ", submissionError.message, "Code", submissionError.code);
+                      warning = `Your concept has been submitted, but it has not been added to the tournament: ${submissionError.message}`;
+                    }
                   }
                 }
               }

--- a/app/(routes)/dashboard/_components/DashboardPage.tsx
+++ b/app/(routes)/dashboard/_components/DashboardPage.tsx
@@ -6,6 +6,7 @@ import AuthContext from "@/app/_context/auth/AuthContext";
 import { useRouter } from "next/navigation";
 import { Bell, FlaskConical, Zap, BookOpen, Mail } from "lucide-react";
 import { getCategoryEmoji, getCategoryBg } from "@/app/_utilities/categoryUtils";
+import { formatStatusLabel } from "@/app/_utilities/tournamentLifecycle";
 
 type TournamentStatus = "upcoming" | "stage1" | "stage2" | "concluded" | "cancelled";
 
@@ -18,6 +19,7 @@ interface Tournament {
   participants: number;
   participantLimit: number;
   status: TournamentStatus;
+  activeRound?: number | null;
 }
 
 function getCountdown(targetDate: string, now: number): { days: number; hours: number } {
@@ -133,23 +135,37 @@ const DashboardPage = () => {
 
       const { data, error: err } = await supabase
         .from("tournament")
-        .select("tournament_id, tournament_title, tournament_genre, tournament_start_date, tournament_end_date, tournament_user_limit, tournament_status, tournament_submission(count)")
+        .select(`
+          tournament_id,
+          tournament_title,
+          tournament_genre,
+          tournament_start_date,
+          tournament_end_date,
+          tournament_user_limit,
+          tournament_status,
+          tournament_submission(count),
+          bracket(bracket_round_number, bracket_status)
+        `)
         .in("tournament_status", ["stage1", "stage2", "upcoming", "concluded"])
         .order("tournament_start_date", { ascending: false });
 
       if (err) {
         setError(err.message);
       } else if (data) {
-        setAllTournaments(data.map((row: any) => ({
-          id: String(row.tournament_id),
-          title: row.tournament_title,
-          category: row.tournament_genre ?? "",
-          startDate: row.tournament_start_date,
-          endDate: row.tournament_end_date,
-          participants: (row.tournament_submission?.[0]?.count ?? 0) as number,
-          participantLimit: row.tournament_user_limit ?? 0,
-          status: row.tournament_status as TournamentStatus,
-        })));
+        setAllTournaments(data.map((row: any) => {
+          const activeBracket = row.bracket?.find((b: any) => b.bracket_status === "active") || row.bracket?.[0];
+          return {
+            id: String(row.tournament_id),
+            title: row.tournament_title,
+            category: row.tournament_genre ?? "",
+            startDate: row.tournament_start_date,
+            endDate: row.tournament_end_date,
+            participants: (row.tournament_submission?.[0]?.count ?? 0) as number,
+            participantLimit: row.tournament_user_limit ?? 0,
+            status: row.tournament_status as TournamentStatus,
+            activeRound: activeBracket ? activeBracket.bracket_round_number : null,
+          };
+        }));
       }
       setLoading(false);
     };
@@ -274,7 +290,7 @@ const DashboardPage = () => {
                     <span className="rounded-full bg-red-50 px-3 py-1 text-xs font-semibold text-red-500">Ending Soon</span>
                   )}
                   <span className="rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-600">
-                    {active[0].status === "stage1" ? "Stage 1" : "Stage 2"}
+                    {formatStatusLabel(active[0].status as any, active[0].activeRound)}
                   </span>
                 </div>
                 <div className="flex -space-x-2">

--- a/app/(routes)/dashboard/_components/DashboardPage.tsx
+++ b/app/(routes)/dashboard/_components/DashboardPage.tsx
@@ -17,6 +17,8 @@ interface Tournament {
   startDate: string;
   endDate: string;
   participants: number;
+  approvedCount: number;
+  pendingCount: number;
   participantLimit: number;
   status: TournamentStatus;
   activeRound?: number | null;
@@ -33,6 +35,14 @@ function getCountdown(targetDate: string, now: number): { days: number; hours: n
 
 function capacityPct(t: Tournament) {
   return t.participantLimit > 0 ? Math.min(100, Math.round((t.participants / t.participantLimit) * 100)) : 0;
+}
+
+function approvedPct(t: Tournament) {
+  return t.participantLimit > 0 ? Math.min(100, Math.round((t.approvedCount / t.participantLimit) * 100)) : 0;
+}
+
+function pendingPct(t: Tournament) {
+  return t.participantLimit > 0 ? Math.min(100, Math.round((t.pendingCount / t.participantLimit) * 100)) : 0;
 }
 
 function slotsLeft(t: Tournament) {
@@ -143,7 +153,7 @@ const DashboardPage = () => {
           tournament_end_date,
           tournament_user_limit,
           tournament_status,
-          tournament_submission(count),
+          tournament_submission(tournamentsub_status),
           bracket(bracket_round_number, bracket_status)
         `)
         .in("tournament_status", ["stage1", "stage2", "upcoming", "concluded"])
@@ -154,13 +164,26 @@ const DashboardPage = () => {
       } else if (data) {
         setAllTournaments(data.map((row: any) => {
           const activeBracket = row.bracket?.find((b: any) => b.bracket_status === "active") || row.bracket?.[0];
+          const allSubs: { tournamentsub_status: string }[] = row.tournament_submission ?? [];
+          // Match admin page: exclude rejected, terminated, deleted
+          const validSubs = allSubs.filter(
+            (s) => s.tournamentsub_status !== "rejected" &&
+                   s.tournamentsub_status !== "terminated" &&
+                   s.tournamentsub_status !== "deleted"
+          );
+          const approvedCount = validSubs.filter((s) => s.tournamentsub_status === "approved").length;
+          const pendingCount = validSubs.filter(
+            (s) => s.tournamentsub_status !== "approved"
+          ).length;
           return {
             id: String(row.tournament_id),
             title: row.tournament_title,
             category: row.tournament_genre ?? "",
             startDate: row.tournament_start_date,
             endDate: row.tournament_end_date,
-            participants: (row.tournament_submission?.[0]?.count ?? 0) as number,
+            participants: validSubs.length,
+            approvedCount,
+            pendingCount,
             participantLimit: row.tournament_user_limit ?? 0,
             status: row.tournament_status as TournamentStatus,
             activeRound: activeBracket ? activeBracket.bracket_round_number : null,
@@ -319,8 +342,19 @@ const DashboardPage = () => {
                   <span className="text-primary font-semibold">{capacityPct(active[0])}% Capacity reached</span>
                   <span className="text-gray-500">{slotsLeft(active[0])} Slots left</span>
                 </div>
-                <div className="h-2 rounded-full bg-gray-100 overflow-hidden">
-                  <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${capacityPct(active[0])}%` }} />
+                <div className="h-2 rounded-full bg-gray-100 overflow-hidden flex">
+                  <div className="h-full rounded-l-full bg-primary transition-all" style={{ width: `${approvedPct(active[0])}%` }} />
+                  <div className="h-full bg-amber-400 transition-all" style={{ width: `${pendingPct(active[0])}%` }} />
+                </div>
+                <div className="flex items-center gap-3 text-[10px] text-gray-500">
+                  <span className="flex items-center gap-1">
+                    <span className="inline-block h-2 w-2 rounded-full bg-primary" />
+                    {active[0].approvedCount} Approved
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span className="inline-block h-2 w-2 rounded-full bg-amber-400" />
+                    {active[0].pendingCount} Pending
+                  </span>
                 </div>
               </div>
 

--- a/app/(routes)/dashboard/_components/DashboardPage.tsx
+++ b/app/(routes)/dashboard/_components/DashboardPage.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useContext } from "react";
 import { supabase } from "@/lib/supabase";
 import AuthContext from "@/app/_context/auth/AuthContext";
 import { useRouter } from "next/navigation";
-import { Bell, FlaskConical, Zap, BookOpen, Mail } from "lucide-react";
+import { Bell, FlaskConical, Zap, BookOpen, Mail, Calendar, Users } from "lucide-react";
 import { getCategoryEmoji, getCategoryBg } from "@/app/_utilities/categoryUtils";
 import { formatStatusLabel } from "@/app/_utilities/tournamentLifecycle";
 
@@ -157,7 +157,7 @@ const DashboardPage = () => {
           bracket(bracket_round_number, bracket_status)
         `)
         .in("tournament_status", ["stage1", "stage2", "upcoming", "concluded"])
-        .order("tournament_start_date", { ascending: false });
+        .order("tournament_end_date", { ascending: false });
 
       if (err) {
         setError(err.message);
@@ -438,7 +438,12 @@ const DashboardPage = () => {
                 "lg:grid-cols-4"
             }`}>
             {concluded.slice(0, 3).map((t, i) => (
-              <div key={t.id} className="rounded-xl overflow-hidden border border-gray-100 bg-white shadow-sm">
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => router.push(`/tournament/${t.id}`)}
+                className="rounded-xl overflow-hidden border border-gray-100 bg-white shadow-sm hover:shadow-md hover:border-primary/30 transition-all cursor-pointer text-left w-full"
+              >
                 <div className={`aspect-[4/3] flex items-center justify-center text-5xl ${["bg-orange-100", "bg-slate-700", "bg-stone-200"][i % 3]}`}>
                   {CHAMPION_EMOJIS[i % CHAMPION_EMOJIS.length]}
                 </div>
@@ -448,8 +453,20 @@ const DashboardPage = () => {
                   </span>
                   <h3 className="font-bold text-gray-900 text-sm leading-snug">{t.title}</h3>
                   {t.category && <p className="text-xs text-gray-500">{t.category}</p>}
+                  <div className="flex items-center gap-3 pt-1 text-[11px] text-gray-400">
+                    {t.endDate && (
+                      <span className="flex items-center gap-1">
+                        <Calendar className="h-3 w-3" />
+                        Ended {t.endDate.slice(0, 10)}
+                      </span>
+                    )}
+                    <span className="flex items-center gap-1">
+                      <Users className="h-3 w-3" />
+                      {t.participants} participants
+                    </span>
+                  </div>
                 </div>
-              </div>
+              </button>
             ))}
 
             {/* Discover More */}

--- a/app/(routes)/dashboard/_components/DashboardPage.tsx
+++ b/app/(routes)/dashboard/_components/DashboardPage.tsx
@@ -124,28 +124,37 @@ const DashboardPage = () => {
   const sidebar = active.slice(1);
 
   useEffect(() => {
-    supabase
-      .from("tournament")
-      .select("tournament_id, tournament_title, tournament_genre, tournament_start_date, tournament_end_date, tournament_user_limit, tournament_status, tournament_submission(count)")
-      .in("tournament_status", ["stage1", "stage2", "upcoming", "concluded"])
-      .order("tournament_start_date", { ascending: false })
-      .then(({ data, error: err }) => {
-        if (err) {
-          setError(err.message);
-        } else if (data) {
-          setAllTournaments(data.map((row: any) => ({
-            id: String(row.tournament_id),
-            title: row.tournament_title,
-            category: row.tournament_genre ?? "",
-            startDate: row.tournament_start_date,
-            endDate: row.tournament_end_date,
-            participants: (row.tournament_submission?.[0]?.count ?? 0) as number,
-            participantLimit: row.tournament_user_limit ?? 0,
-            status: row.tournament_status as TournamentStatus,
-          })));
-        }
-        setLoading(false);
-      });
+    const fetchDashboardTournaments = async () => {
+      try {
+        await supabase.rpc("run_tournament_cron");
+      } catch (e) {
+        console.warn("Cron update check failed:", e);
+      }
+
+      const { data, error: err } = await supabase
+        .from("tournament")
+        .select("tournament_id, tournament_title, tournament_genre, tournament_start_date, tournament_end_date, tournament_user_limit, tournament_status, tournament_submission(count)")
+        .in("tournament_status", ["stage1", "stage2", "upcoming", "concluded"])
+        .order("tournament_start_date", { ascending: false });
+
+      if (err) {
+        setError(err.message);
+      } else if (data) {
+        setAllTournaments(data.map((row: any) => ({
+          id: String(row.tournament_id),
+          title: row.tournament_title,
+          category: row.tournament_genre ?? "",
+          startDate: row.tournament_start_date,
+          endDate: row.tournament_end_date,
+          participants: (row.tournament_submission?.[0]?.count ?? 0) as number,
+          participantLimit: row.tournament_user_limit ?? 0,
+          status: row.tournament_status as TournamentStatus,
+        })));
+      }
+      setLoading(false);
+    };
+
+    fetchDashboardTournaments();
   }, []);
 
   useEffect(() => {

--- a/app/(routes)/leaderboard/_components/LeaderboardPage.tsx
+++ b/app/(routes)/leaderboard/_components/LeaderboardPage.tsx
@@ -35,6 +35,12 @@ const LeaderBoardPage = () => {
 
     const fetchTournaments = async () => {
       try {
+        try {
+          await supabase.rpc("run_tournament_cron");
+        } catch (e) {
+          console.warn("Cron update check failed:", e);
+        }
+
         const { data, error } = await supabase
           .from("tournament")
           .select(`

--- a/app/(routes)/past-tournaments/_components/PastTournamentsPage.tsx
+++ b/app/(routes)/past-tournaments/_components/PastTournamentsPage.tsx
@@ -25,25 +25,35 @@ const PastTournamentsPage = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    supabase
-      .from("tournament")
-      .select("tournament_id, tournament_title, tournament_genre, tournament_end_date, tournament_submission(count)")
-      .eq("tournament_status", "concluded")
-      .eq("tournament_submission.tournamentsub_status", "approved")
-      .order("tournament_end_date", { ascending: false })
-      .then(({ data, error: err }) => {
-        if (err) { setError(err.message); }
-        else if (data) {
-          setTournaments(data.map((row: any) => ({
-            id: String(row.tournament_id),
-            title: row.tournament_title,
-            category: row.tournament_genre ?? "",
-            endDate: row.tournament_end_date ?? "",
-            participants: (row.tournament_submission?.[0]?.count ?? 0) as number,
-          })));
-        }
-        setLoading(false);
-      });
+    const fetchPastTournaments = async () => {
+      try {
+        await supabase.rpc("run_tournament_cron");
+      } catch (e) {
+        console.warn("Cron update check failed:", e);
+      }
+
+      const { data, error: err } = await supabase
+        .from("tournament")
+        .select("tournament_id, tournament_title, tournament_genre, tournament_end_date, tournament_submission(count)")
+        .eq("tournament_status", "concluded")
+        .eq("tournament_submission.tournamentsub_status", "approved")
+        .order("tournament_end_date", { ascending: false });
+
+      if (err) {
+        setError(err.message);
+      } else if (data) {
+        setTournaments(data.map((row: any) => ({
+          id: String(row.tournament_id),
+          title: row.tournament_title,
+          category: row.tournament_genre ?? "",
+          endDate: row.tournament_end_date ?? "",
+          participants: (row.tournament_submission?.[0]?.count ?? 0) as number,
+        })));
+      }
+      setLoading(false);
+    };
+
+    fetchPastTournaments();
   }, []);
 
   return (

--- a/app/(routes)/tournament/[id]/_components/TournamentPage.tsx
+++ b/app/(routes)/tournament/[id]/_components/TournamentPage.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { BookCover } from "@/app/_types/model/Concept";
 import {
   formatCountdownParts,
+  formatStatusLabel,
   getCountdownParts,
   getTournamentMilestoneTarget,
   resolveTournamentLifecycleStatus,
@@ -48,6 +49,9 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
   const [loading, setLoading] = useState(true);
   const [now, setNow] = useState(() => Date.now());
 
+  const [activeRound, setActiveRound] = useState<number | null>(null);
+  const [totalRounds, setTotalRounds] = useState<number | null>(null);
+
   const truncateText = (text: string, maxLength: number) => {
     if (text.length <= maxLength) return text;
     return text.substring(0, maxLength) + "...";
@@ -73,6 +77,35 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
     }
 
     setTournamentData(data);
+
+    try {
+      const { data: bracketRows } = await supabase
+        .from("bracket")
+        .select("bracket_id, bracket_round_number, bracket_status")
+        .eq("tournament_id", Number(id));
+
+      if (bracketRows && bracketRows.length > 0) {
+        const activeBracket = bracketRows.find(b => b.bracket_status === "active") || bracketRows[0];
+        setActiveRound(activeBracket.bracket_round_number);
+
+        const bracketIds = bracketRows.map(b => b.bracket_id);
+        const { data: matches } = await supabase
+          .from("bracket_match")
+          .select("bmatch_index")
+          .in("bracket_id", bracketIds);
+
+        if (matches && matches.length > 0) {
+          const r1Count = matches.filter(m => (m.bmatch_index?.round ?? 1) === 1).length;
+          const computedTotalRounds = Math.max(1, Math.ceil(Math.log2(r1Count * 2)));
+          setTotalRounds(computedTotalRounds);
+        } else {
+          setTotalRounds(1);
+        }
+      }
+    } catch (e) {
+      console.warn("Error fetching bracket rounds:", e);
+    }
+
     setLoading(false);
   }, [id]);
 
@@ -145,8 +178,8 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
   }, [now, tournamentData?.tournament_end_date]);
 
   const milestone = useMemo(() => {
-    return getTournamentMilestoneTarget(tournamentData, resolvedStatus);
-  }, [resolvedStatus, tournamentData]);
+    return getTournamentMilestoneTarget(tournamentData, resolvedStatus, activeRound, totalRounds);
+  }, [resolvedStatus, tournamentData, activeRound, totalRounds]);
 
   const milestoneCountdown = useMemo(() => {
     return getCountdownParts(milestone.targetMs, now);
@@ -169,7 +202,13 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
       <div className="mx-auto max-w-6xl">
         <section className="rounded-2xl bg-[#baffe5af] px-10 py-12 shadow-lg">
           <div className={`mb-4 inline-block rounded-full px-4 py-1 text-sm font-bold ${statusStyles[resolvedStatus]}`}>
-            {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)} Tournament
+            {resolvedStatus === "stage1" || resolvedStatus === "stage2"
+              ? "Active Tournament"
+              : resolvedStatus === "upcoming"
+                ? "Upcoming Tournament"
+                : resolvedStatus === "concluded"
+                  ? "Concluded Tournament"
+                  : "Terminated Tournament"}
           </div>
 
           <h1 className="max-w-2xl text-4xl font-bold leading-tight text-purple-950">{tournamentData.tournament_title}</h1>
@@ -177,7 +216,7 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
             {tournamentData.tournament_genre}
           </div>
           <div className="mb-4 inline-block rounded-full bg-purple-300 px-4 py-1 text-sm font-bold text-purple-900">
-            {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)}
+            {formatStatusLabel(resolvedStatus, activeRound)}
           </div>
 
           <p className="max-w-3xl text-md text-gray-700">

--- a/app/(routes)/tournament/[id]/_components/TournamentPage.tsx
+++ b/app/(routes)/tournament/[id]/_components/TournamentPage.tsx
@@ -3,16 +3,23 @@
 import TournamentContext from "@/app/_context/tournament/TournamentContext";
 import { supabase } from "@/lib/supabase";
 import { useRouter } from "next/navigation";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { BookCover } from "@/app/_types/model/Concept";
-
-
+import {
+  formatCountdownParts,
+  getCountdownParts,
+  getTournamentMilestoneTarget,
+  resolveTournamentLifecycleStatus,
+  TournamentLifecycleStatus,
+} from "@/app/_utilities/tournamentLifecycle";
 
 type Tournament = {
   tournament_id: number;
   tournament_title: string;
   tournament_genre: string;
+  tournament_start_date: string;
+  tournament_s2_start_date: string | null;
   tournament_status: string;
   tournament_end_date: string;
   description: string;
@@ -34,59 +41,45 @@ type ConceptSubmission = {
 
 const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boolean }) => {
   const router = useRouter();
-  const { tournament, setTournament } = useContext(TournamentContext);
+  const { setTournament } = useContext(TournamentContext);
 
   const [tournamentData, setTournamentData] = useState<Tournament | null>(null);
   const [conceptSubmissions, setConceptSubmissions] = useState<ConceptSubmission[]>([]);
   const [loading, setLoading] = useState(true);
+  const [now, setNow] = useState(() => Date.now());
 
   const truncateText = (text: string, maxLength: number) => {
     if (text.length <= maxLength) return text;
-    return text.substring(0, maxLength) + '...';
+    return text.substring(0, maxLength) + "...";
   };
 
-  const getTimeLeft = (endDate?: string) => {
-    if (!endDate) {
-      return { days: 0, hours: 0, minutes: 0 };
+  const fetchTournamentData = useCallback(async () => {
+    try {
+      await supabase.rpc("advance_tournament_lifecycle", { p_tournament_id: Number(id) });
+    } catch (e) {
+      console.warn("Lifecycle update check failed:", e);
     }
 
-    const difference = new Date(endDate).getTime() - Date.now();
+    const { data, error } = await supabase
+      .from("tournament")
+      .select("*")
+      .eq("tournament_id", Number(id))
+      .single();
 
-    if (difference <= 0) {
-      return { days: 0, hours: 0, minutes: 0 };
+    if (error) {
+      console.error("Error fetching tournament data:", error);
+      setLoading(false);
+      return;
     }
 
-    return {
-      days: Math.floor(difference / (1000 * 60 * 60 * 24)),
-      hours: Math.floor((difference / (1000 * 60 * 60)) % 24),
-      minutes: Math.floor((difference / (1000 * 60)) % 60),
-    };
-  };
-
-  const [timeLeft, setTimeLeft] = useState(() => getTimeLeft());
+    setTournamentData(data);
+    setLoading(false);
+  }, [id]);
 
   useEffect(() => {
     setTournament(Number(id));
-
-    const getTournamentData = async () => {
-      const { data, error } = await supabase
-        .from("tournament")
-        .select("*")
-        .eq("tournament_id", Number(id))
-        .single();
-
-      if (error) {
-        console.error("Error fetching tournament data:", error);
-        setLoading(false);
-        return;
-      }
-
-      setTournamentData(data);
-      setLoading(false);
-    };
-    getTournamentData();
-
-  }, [id, setTournament]);
+    fetchTournamentData();
+  }, [fetchTournamentData, id, setTournament]);
 
   useEffect(() => {
     const getConceptSubmissions = async () => {
@@ -126,43 +119,46 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
   }, [tournamentData, id]);
 
   useEffect(() => {
-    if (readonly) return;
+    const timerId = window.setInterval(() => setNow(Date.now()), 15000);
+    return () => window.clearInterval(timerId);
+  }, []);
 
-    if (!tournamentData?.tournament_end_date) {
-      setTimeLeft({ days: 0, hours: 0, minutes: 0 });
-      return;
-    }
+  useEffect(() => {
+    if (!tournamentData) return;
 
-    let timeoutId: number | undefined;
+    const timerId = window.setInterval(() => {
+      fetchTournamentData();
+    }, 30000);
 
-    const scheduleNextUpdate = () => {
-      const nextTimeLeft = getTimeLeft(tournamentData.tournament_end_date);
-      setTimeLeft(nextTimeLeft);
+    return () => window.clearInterval(timerId);
+  }, [fetchTournamentData, tournamentData]);
 
-      if (
-        nextTimeLeft.days === 0 &&
-        nextTimeLeft.hours === 0 &&
-        nextTimeLeft.minutes === 0
-      ) {
-        return;
-      }
+  const resolvedStatus = useMemo<TournamentLifecycleStatus>(() => {
+    return resolveTournamentLifecycleStatus(tournamentData, now);
+  }, [now, tournamentData]);
 
-      const endDate = new Date(tournamentData.tournament_end_date).getTime();
-      const now = Date.now();
-      const diff = endDate - now;
-      const delay = diff > 0 ? Math.max(diff % 60000, 1000) : 1000;
+  const totalCountdown = useMemo(() => {
+    return getCountdownParts(
+      tournamentData?.tournament_end_date ? new Date(tournamentData.tournament_end_date).getTime() : null,
+      now,
+    );
+  }, [now, tournamentData?.tournament_end_date]);
 
-      timeoutId = window.setTimeout(scheduleNextUpdate, delay);
-    };
+  const milestone = useMemo(() => {
+    return getTournamentMilestoneTarget(tournamentData, resolvedStatus);
+  }, [resolvedStatus, tournamentData]);
 
-    scheduleNextUpdate();
+  const milestoneCountdown = useMemo(() => {
+    return getCountdownParts(milestone.targetMs, now);
+  }, [milestone.targetMs, now]);
 
-    return () => {
-      if (timeoutId !== undefined) {
-        window.clearTimeout(timeoutId);
-      }
-    };
-  }, [readonly, tournamentData?.tournament_end_date]);
+  const statusStyles: Record<TournamentLifecycleStatus, string> = {
+    upcoming: "bg-[#fff7e6] text-[#b97805]",
+    stage1: "bg-[#e0f0ff] text-[#1565c0]",
+    stage2: "bg-[#ede9fe] text-[#6d3ef0]",
+    concluded: "bg-[#e6f9f0] text-[#1a8a55]",
+    terminated: "bg-[#f0f1f7] text-[#4b5563]",
+  };
 
   if (loading) return <p>Loading tournament...</p>;
 
@@ -171,13 +167,9 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
   return (
     <div className="min-h-screen bg-white px-6 py-10">
       <div className="mx-auto max-w-6xl">
-
         <section className="rounded-2xl bg-[#baffe5af] px-10 py-12 shadow-lg">
-          <div className={`mb-4 inline-block rounded-full px-4 py-1 text-sm font-bold ${tournamentData.tournament_status === "active"
-            ? "bg-tertiary text-orange-900"
-            : "bg-gray-200 text-gray-600"
-            }`}>
-            {tournamentData.tournament_status !== "concluded" ? "Active Tournament" : "Concluded Tournament"}
+          <div className={`mb-4 inline-block rounded-full px-4 py-1 text-sm font-bold ${statusStyles[resolvedStatus]}`}>
+            {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)} Tournament
           </div>
 
           <h1 className="max-w-2xl text-4xl font-bold leading-tight text-purple-950">{tournamentData.tournament_title}</h1>
@@ -185,43 +177,45 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
             {tournamentData.tournament_genre}
           </div>
           <div className="mb-4 inline-block rounded-full bg-purple-300 px-4 py-1 text-sm font-bold text-purple-900">
-            {tournamentData.tournament_status.charAt(0).toUpperCase() + tournamentData.tournament_status.slice(1)}
+            {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)}
           </div>
 
-
           <p className="max-w-3xl text-md text-gray-700">
-            {tournamentData.tournament_status === "active"
+            {resolvedStatus === "stage1" || resolvedStatus === "stage2"
               ? "Join as the most creative concepts face off in the ultimate STEM showdown! Vote for your favourite concepts to shape their future."
               : "Browse the concepts that competed in this concluded tournament."}
           </p>
-
         </section>
 
-        {!readonly && <section className="mt-10 rounded-[2rem] bg-[whitesmoke] px-8 py-10 text-center shadow-lg">
-          <p className="text-xs font-extrabold uppercase tracking-widest text-emerald-700">
-            Time remaining to vote
-          </p>
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-purple-600">
-
-            <div className="rounded-3xl border border-purple-200 bg-purple-50 px-8 py-8 shadow-sm">
-              <div className="text-5xl font-extrabold">{timeLeft.days}</div>
-              <div className="mt-2 text-sm uppercase tracking-[0.2em] text-purple-700">Days</div>
-            </div>
-            <span className="text-6xl font-extrabold">:</span>
-
-            <div className="rounded-3xl border border-purple-200 bg-purple-50 px-8 py-8 shadow-sm">
-              <div className="text-5xl font-extrabold">{timeLeft.hours}</div>
-              <div className="mt-2 text-sm uppercase tracking-[0.2em] text-purple-700">Hours</div>
-            </div>
-            <span className="text-6xl font-extrabold">:</span>
-
-            <div className="rounded-3xl border border-purple-200 bg-purple-50 px-8 py-8 shadow-sm">
-              <div className="text-5xl font-extrabold">{timeLeft.minutes}</div>
-              <div className="mt-2 text-sm uppercase tracking-[0.2em] text-purple-700">Minutes</div>
+        {!readonly && (
+          <section className="mt-10 rounded-[2rem] bg-[whitesmoke] px-8 py-10 text-center shadow-lg">
+            <div className="flex flex-wrap items-center justify-between gap-4 text-left">
+              <div>
+                <p className="text-xs font-extrabold uppercase tracking-widest text-emerald-700">
+                  Live Tournament Clock
+                </p>
+                <h2 className="mt-2 text-2xl font-black tracking-[-0.04em] text-[#1d2436]">
+                  Total and stage countdowns
+                </h2>
+              </div>
+              <span className="rounded-full bg-white px-4 py-2 text-xs font-bold uppercase tracking-[0.12em] text-[#6b7490] shadow-sm">
+                Auto-refreshes every 15s
+              </span>
             </div>
 
-          </div>
-        </section>}
+            <div className="mt-8 grid gap-4 md:grid-cols-2">
+              <div className="rounded-3xl border border-purple-200 bg-purple-50 px-8 py-8 shadow-sm">
+                <div className="text-xs font-black uppercase tracking-[0.14em] text-purple-700">Tournament ends in</div>
+                <div className="mt-3 text-4xl font-extrabold text-purple-900">{formatCountdownParts(totalCountdown)}</div>
+              </div>
+
+              <div className="rounded-3xl border border-emerald-200 bg-emerald-50 px-8 py-8 shadow-sm">
+                <div className="text-xs font-black uppercase tracking-[0.14em] text-emerald-700">{milestone.label}</div>
+                <div className="mt-3 text-4xl font-extrabold text-emerald-900">{formatCountdownParts(milestoneCountdown)}</div>
+              </div>
+            </div>
+          </section>
+        )}
 
         <section className="mt-10">
           <div className="flex justify-between items-start mb-6">
@@ -242,31 +236,30 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
           {conceptSubmissions.length > 0 ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {conceptSubmissions.map((submission) => {
-                // Calculate coverUrl here (copied from ProfileBookCard logic)
-                const fallbackCoverUrl = '/covers/engineering.png';
+                const fallbackCoverUrl = "/covers/engineering.png";
                 const fallbackStyling = { book_cover: fallbackCoverUrl } as BookCover;
                 const rawConceptStyling = submission.concept.concept_styling as unknown;
                 let styling: BookCover = fallbackStyling;
 
-                if (typeof rawConceptStyling === 'string') {
+                if (typeof rawConceptStyling === "string") {
                   try {
                     const parsedStyling = JSON.parse(rawConceptStyling) as unknown;
-                    if (parsedStyling && typeof parsedStyling === 'object') {
+                    if (parsedStyling && typeof parsedStyling === "object") {
                       styling = parsedStyling as BookCover;
                     }
                   } catch {
                     styling = fallbackStyling;
                   }
-                } else if (rawConceptStyling && typeof rawConceptStyling === 'object') {
+                } else if (rawConceptStyling && typeof rawConceptStyling === "object") {
                   styling = rawConceptStyling as BookCover;
                 }
 
-                const bookCover = typeof styling.book_cover === 'string'
+                const bookCover = typeof styling.book_cover === "string"
                   ? styling.book_cover
                   : fallbackStyling.book_cover;
                 let coverUrl = fallbackCoverUrl;
                 if (bookCover) {
-                  const isLocalPath = bookCover.startsWith('/');
+                  const isLocalPath = bookCover.startsWith("/");
                   const isAbsoluteUrl = /^(https?:)?\/\//.test(bookCover);
                   if (isLocalPath || isAbsoluteUrl) {
                     coverUrl = bookCover;
@@ -295,7 +288,7 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
 
                       <p className="text-sm text-gray-700 mb-4 flex-1">{truncateText(submission.concept.concept_description, 25)}</p>
 
-                      <div className="flex items-center justify-between mb-3  mt-auto">
+                      <div className="flex items-center justify-between mb-3 mt-auto">
                         <span className="text-lg font-semibold text-purple-600 flex-shrink-0"></span>
 
                         {!readonly && <Button onClick={() => router.push(`/tournament/${id}/submissions`)}
@@ -323,7 +316,6 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
           </div>
 
           <Button
-
             className="py-2 px-6 text-white bg-purple-600 hover:bg-purple-700"
             onClick={() => router.push(`/tournament/${id}/tournamentbracket`)}
           >
@@ -334,7 +326,5 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
     </div>
   );
 };
-
-
 
 export default TournamentPage;

--- a/app/(routes)/tournament/[id]/_components/TournamentPage.tsx
+++ b/app/(routes)/tournament/[id]/_components/TournamentPage.tsx
@@ -187,7 +187,7 @@ const TournamentPage = ({ id, readonly = false }: { id: string; readonly?: boole
           </p>
         </section>
 
-        {!readonly && (
+        {!readonly && resolvedStatus !== "concluded" && resolvedStatus !== "terminated" && (
           <section className="mt-10 rounded-[2rem] bg-[whitesmoke] px-8 py-10 text-center shadow-lg">
             <div className="flex flex-wrap items-center justify-between gap-4 text-left">
               <div>

--- a/app/(routes)/tournament/[id]/submissions/_components/SubmissionsPage.tsx
+++ b/app/(routes)/tournament/[id]/submissions/_components/SubmissionsPage.tsx
@@ -9,14 +9,129 @@ import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 
 const SubmissionsPage = () => {
-  const { isGridMode, setIsGridMode, books } = useContext(BookContext);
+  const { isGridMode, setIsGridMode, books, setBooks } = useContext(BookContext);
   const router = useRouter();
   const [title, setTitle] = useState("");
   const [tournamentStatus, setTournamentStatus] = useState<string | null>(null);
   const [showingLiked, setShowingLiked] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [bulkAdding, setBulkAdding] = useState(false);
   const params = useParams<{ id: string }>();
   const id = params.id;
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) return;
+        const { data: profile, error } = await supabase
+          .from("user")
+          .select("user_role")
+          .eq("user_id", user.id)
+          .single();
+        if (!error && profile && profile.user_role === "admin") {
+          setIsAdmin(true);
+        }
+      } catch (e) {
+        console.warn("Admin check failed:", e);
+      }
+    })();
+  }, []);
+
+  const handleAddAllConcepts = async () => {
+    if (bulkAdding) return;
+    setBulkAdding(true);
+    try {
+      const { data: tournament, error: tErr } = await supabase
+        .from("tournament")
+        .select("tournament_user_limit")
+        .eq("tournament_id", id)
+        .single();
+
+      if (tErr || !tournament) {
+        alert("Failed to fetch tournament limit details.");
+        return;
+      }
+
+      const limit = Number(tournament.tournament_user_limit ?? 0);
+
+      const { count, error: countErr } = await supabase
+        .from("tournament_submission")
+        .select("*", { count: "exact", head: true })
+        .eq("tournament_id", id);
+
+      if (countErr) {
+        alert("Failed to check current submissions count.");
+        return;
+      }
+
+      const currentCount = count ?? 0;
+      const slotsRemaining = limit - currentCount;
+
+      if (slotsRemaining <= 0) {
+        alert(`The tournament has already reached its submission limit of ${limit}.`);
+        return;
+      }
+
+      const { data: existingSubs, error: subsErr } = await supabase
+        .from("tournament_submission")
+        .select("concept_id")
+        .eq("tournament_id", id);
+
+      if (subsErr) {
+        alert("Failed to fetch existing tournament submissions.");
+        return;
+      }
+
+      const existingConceptIds = existingSubs?.map(s => s.concept_id) ?? [];
+
+      const { data: allConcepts, error: conceptsErr } = await supabase
+        .from("concept")
+        .select("concept_id")
+        .not("concept_status", "eq", "deleted");
+
+      if (conceptsErr) {
+        alert("Failed to fetch concepts from database.");
+        return;
+      }
+
+      const availableConcepts = (allConcepts ?? []).filter(
+        c => !existingConceptIds.includes(c.concept_id)
+      );
+
+      if (availableConcepts.length === 0) {
+        alert("No new concepts available in the database to add.");
+        return;
+      }
+
+      const toAdd = availableConcepts.slice(0, slotsRemaining);
+
+      const rowsToInsert = toAdd.map(c => ({
+        tournament_id: Number(id),
+        concept_id: c.concept_id,
+        tournamentsub_status: "approved"
+      }));
+
+      const { error: insertErr } = await supabase
+        .from("tournament_submission")
+        .insert(rowsToInsert);
+
+      if (insertErr) {
+        alert("Failed to insert concept submissions: " + insertErr.message);
+        return;
+      }
+
+      alert(`Successfully added and approved ${toAdd.length} concepts to the tournament!`);
+      await setBooks(String(id));
+
+    } catch (err) {
+      console.error("Bulk add concepts failed:", err);
+      alert("An unexpected error occurred during bulk add.");
+    } finally {
+      setBulkAdding(false);
+    }
+  };
 
   const likedBooks = books.filter(book => book.isLiked);
   const hasLikedBooks = likedBooks.length > 0;
@@ -89,7 +204,16 @@ const SubmissionsPage = () => {
           )
         )
         }
-        <div className="flex ml-auto">
+        <div className="flex ml-auto items-center">
+          {isAdmin && tournamentStatus === "stage1" && (
+            <button
+              className="rounded-lg bg-purple-700 p-2 text-sm font-semibold text-white hover:bg-purple-800 transition-colors cursor-pointer mr-2"
+              onClick={handleAddAllConcepts}
+              disabled={bulkAdding}
+            >
+              {bulkAdding ? "Adding Concepts..." : "Add & Approve All Concepts"}
+            </button>
+          )}
           <button className="rounded-lg bg-primary p-2 text-sm font-semibold text-white hover:bg-primary/90 transition-colors cursor-pointer" onClick={handleModeToggle}>
             {isGridMode ? "Swipe Mode" : "Grid Mode"}
           </button>

--- a/app/(routes)/tournament/[id]/submissions/_components/SubmissionsPage.tsx
+++ b/app/(routes)/tournament/[id]/submissions/_components/SubmissionsPage.tsx
@@ -56,17 +56,21 @@ const SubmissionsPage = () => {
 
       const limit = Number(tournament.tournament_user_limit ?? 0);
 
-      const { count, error: countErr } = await supabase
+      // Only count valid (approved + pending) submissions — same logic as admin/dashboard
+      const { data: validSubsData, error: countErr } = await supabase
         .from("tournament_submission")
-        .select("*", { count: "exact", head: true })
-        .eq("tournament_id", id);
+        .select("concept_id, tournamentsub_status")
+        .eq("tournament_id", id)
+        .not("tournamentsub_status", "eq", "rejected")
+        .not("tournamentsub_status", "eq", "terminated")
+        .not("tournamentsub_status", "eq", "deleted");
 
       if (countErr) {
         alert("Failed to check current submissions count.");
         return;
       }
 
-      const currentCount = count ?? 0;
+      const currentCount = validSubsData?.length ?? 0;
       const slotsRemaining = limit - currentCount;
 
       if (slotsRemaining <= 0) {
@@ -74,17 +78,8 @@ const SubmissionsPage = () => {
         return;
       }
 
-      const { data: existingSubs, error: subsErr } = await supabase
-        .from("tournament_submission")
-        .select("concept_id")
-        .eq("tournament_id", id);
-
-      if (subsErr) {
-        alert("Failed to fetch existing tournament submissions.");
-        return;
-      }
-
-      const existingConceptIds = existingSubs?.map(s => s.concept_id) ?? [];
+      // Exclude concepts that already have a valid (non-rejected/terminated/deleted) submission
+      const existingConceptIds = validSubsData?.map(s => s.concept_id) ?? [];
 
       const { data: allConcepts, error: conceptsErr } = await supabase
         .from("concept")

--- a/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
@@ -52,6 +52,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
   const [selectedSide, setSelectedSide] = useState<"a" | "b" | null>(null);
   const [isVoting, setIsVoting] = useState(false);
   const [voteSuccess, setVoteSuccess] = useState(false);
+  const [successMessage, setSuccessMessage] = useState("");
 
 
   const [isSubmittingVote, setIsSubmittingVote] = useState(false);
@@ -67,6 +68,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
   const [bracket, setBracket] = useState<Bracket | null>(null);
   const [totalRounds, setTotalRounds] = useState(1);
   const [activeRound, setActiveRound] = useState(1);
+  const [matchRound, setMatchRound] = useState(1);
 
   const [book1, setBook1] = useState<Concept | null>(null);
   const [book2, setBook2] = useState<Concept | null>(null);
@@ -94,6 +96,10 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
         .single();
 
       if (matchError) throw matchError;
+
+      if (match) {
+        setMatchRound(match.bmatch_index?.round ?? 1);
+      }
 
       const { data: bracketData, error: bracketError } = await supabase
         .from("bracket")
@@ -247,8 +253,8 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
   }, [milestone.targetMs, now]);
 
   const roundCountdownTarget = useMemo(() => {
-    return getRoundCountdownTarget(tournament, totalRounds, activeRound);
-  }, [activeRound, totalRounds, tournament]);
+    return getRoundCountdownTarget(tournament, totalRounds, matchRound);
+  }, [matchRound, totalRounds, tournament]);
 
   const roundCountdown = useMemo(() => {
     return getCountdownParts(roundCountdownTarget, now);
@@ -264,21 +270,14 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
       return;
     }
 
-
-    if (userVote === selectedSide) {
-      setIsVoting(false);
-      return;
-    }
-
-    // Prevent voting unless the tournament is in stage2
-    if (resolvedStatus !== "stage2") {
-      alert("Voting is not open for this tournament.");
+    // Prevent voting unless the tournament is in stage2 and this match belongs to the active round
+    if (resolvedStatus !== "stage2" || matchRound !== activeRound) {
+      alert("Voting is not open for this match.");
       setIsVoting(false);
       return;
     }
 
     setIsSubmittingVote(true);
-
 
     const { data: { user } } = await supabase.auth.getUser();
 
@@ -288,42 +287,62 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
       return;
     }
 
-    const newSubmissionId =
-      selectedSide === "a" ? submissionAId : submissionBId;
-
-    if (!newSubmissionId) {
-      console.error("Submission ID missing");
-      setIsSubmittingVote(false);
-      return;
-    }
-
-
     try {
+      if (userVote === selectedSide) {
+        // Cancel Vote
+        const { error } = await supabase
+          .from("vote")
+          .delete()
+          .eq("bmatch_id", bmatchId)
+          .eq("user_id", user.id);
 
-      // ── UPDATE existing vote row ──────────────────────────────────────
-      const { error } = await supabase
-        .from("vote")
-        .upsert({
-          bmatch_id: bmatchId,
-          user_id: user.id,
-          tournamentsub_id: newSubmissionId,
-        }, {
-          onConflict: "bmatch_id,user_id"
-        });
+        if (error) throw error;
 
-      if (error) throw error;
+        setUserVote(null);
+        setSuccessMessage(`✓ Your vote for ${selectedBook} has been cancelled.`);
+        setVoteSuccess(true);
+        setTimeout(() => {
+          setVoteSuccess(false);
+          setIsVoting(false);
+        }, 3000);
+      } else {
+        // Vote or Switch Vote
+        const newSubmissionId =
+          selectedSide === "a" ? submissionAId : submissionBId;
 
-      setUserVote(selectedSide);
+        if (!newSubmissionId) {
+          console.error("Submission ID missing");
+          setIsSubmittingVote(false);
+          return;
+        }
 
-      setVoteSuccess(true);
-      setTimeout(() => {
-        setVoteSuccess(false);
-        setIsVoting(false);
-      }, 3000);
+        const { error } = await supabase
+          .from("vote")
+          .upsert({
+            bmatch_id: bmatchId,
+            user_id: user.id,
+            tournamentsub_id: newSubmissionId,
+          }, {
+            onConflict: "bmatch_id,user_id"
+          });
 
+        if (error) throw error;
 
+        const isSwitch = userVote !== null;
+        setUserVote(selectedSide);
+        setSuccessMessage(
+          isSwitch
+            ? `✓ Your vote has been switched to ${selectedBook}!`
+            : `✓ Your vote for ${selectedBook} has been submitted!`
+        );
+        setVoteSuccess(true);
+        setTimeout(() => {
+          setVoteSuccess(false);
+          setIsVoting(false);
+        }, 3000);
+      }
     } catch (err) {
-      console.error("vote failed", err);
+      console.error("operation failed", err);
     } finally {
       setIsVoting(false);
       setIsSubmittingVote(false);
@@ -348,11 +367,15 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
         <div className="flex justify-between items-start">
           <h1 className=" md:text-5xl font-headline font-bold text-on-surface tracking-tighter pt-3 ">
-            {tournament?.tournament_title}</h1>
+            {tournament?.tournament_title} - One Vs One</h1>
 
-          <div className={`rounded-full px-5 py-3 text-sm font-semibold shadow-lg mb-3 ${resolvedStatus === "stage2" ? "bg-green-100 text-blue-800" : "bg-slate-100 text-slate-700"}`}>
+          <div className={`rounded-full px-5 py-3 text-sm font-semibold shadow-lg mb-3 ${resolvedStatus === "stage2" && matchRound === activeRound ? "bg-green-100 text-blue-800" : "bg-slate-100 text-slate-700"}`}>
             {resolvedStatus === "stage2"
-              ? `Round ${activeRound} voting ends in ${formatCountdownParts(roundCountdown)}`
+              ? matchRound === activeRound
+                ? `Round ${matchRound} voting ends in ${formatCountdownParts(roundCountdown)}`
+                : matchRound < activeRound
+                  ? `Round ${matchRound} voting has ended`
+                  : `Round ${matchRound} voting hasn't started`
               : resolvedStatus === "stage1"
                 ? `Stage 2 starts in ${formatCountdownParts(milestoneCountdown)}`
                 : resolvedStatus === "upcoming"
@@ -362,13 +385,12 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
         </div>
         <div className="mt-3 flex flex-wrap items-center gap-3">
           <span className="rounded-full bg-purple-100 px-4 py-2 text-sm font-bold text-purple-800">
-            {formatStatusLabel(resolvedStatus, activeRound)}
+            {formatStatusLabel(resolvedStatus, matchRound)}
           </span>
           <span className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm">
-            Round {activeRound} of {totalRounds}
+            Round {matchRound} of {totalRounds}
           </span>
         </div>
-        <p className="mb-2 max-w-4xl text-base font-bold text-gray-500 sm:text-xl pt-3">{bracket?.bracket_round_number} One vs One</p>
 
         {resolvedStatus !== "concluded" && resolvedStatus !== "terminated" && (
           <div className="mt-6 grid gap-4 md:grid-cols-2">
@@ -378,10 +400,22 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
             </div>
 
             {resolvedStatus === "stage2" && (
-              <div className="rounded-3xl border border-emerald-200 bg-emerald-50 p-5 shadow-sm">
-                <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Round {activeRound} voting ends</p>
-                <p className="mt-3 text-3xl font-extrabold text-emerald-900">{formatCountdownParts(roundCountdown)}</p>
-              </div>
+              matchRound === activeRound ? (
+                <div className="rounded-3xl border border-emerald-200 bg-emerald-50 p-5 shadow-sm">
+                  <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Round {matchRound} voting ends</p>
+                  <p className="mt-3 text-3xl font-extrabold text-emerald-900">{formatCountdownParts(roundCountdown)}</p>
+                </div>
+              ) : matchRound < activeRound ? (
+                <div className="rounded-3xl border border-slate-200 bg-slate-50 p-5 shadow-sm">
+                  <p className="text-xs font-black uppercase tracking-[0.16em] text-slate-700">Round {matchRound} voting</p>
+                  <p className="mt-3 text-3xl font-extrabold text-slate-900">Voting has ended</p>
+                </div>
+              ) : (
+                <div className="rounded-3xl border border-slate-200 bg-slate-50 p-5 shadow-sm">
+                  <p className="text-xs font-black uppercase tracking-[0.16em] text-slate-700">Round {matchRound} voting</p>
+                  <p className="mt-3 text-3xl font-extrabold text-slate-900">Upcoming</p>
+                </div>
+              )
             )}
           </div>
         )}
@@ -418,18 +452,32 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
 
                 <div className="mt-5 flex justify-center">
-                  {resolvedStatus === "stage2" && (
-                    <Button
-                      className="pointer-events-auto bg-green-300 hover:bg-green-400 text-gray-700 px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setSelectedBook(book1.concept_title);
-                        setSelectedSide("a")
-                        setIsVoting(true);
-                      }}
-                    >
-                      Vote
-                    </Button>
+                  {resolvedStatus === "stage2" && matchRound === activeRound && (
+                    userVote === "a" ? (
+                      <Button
+                        className="pointer-events-auto bg-red-500 hover:bg-red-600 text-white px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedBook(book1.concept_title);
+                          setSelectedSide("a");
+                          setIsVoting(true);
+                        }}
+                      >
+                        Cancel Vote
+                      </Button>
+                    ) : (
+                      <Button
+                        className="pointer-events-auto bg-green-300 hover:bg-green-400 text-gray-700 px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedBook(book1.concept_title);
+                          setSelectedSide("a");
+                          setIsVoting(true);
+                        }}
+                      >
+                        {userVote === "b" ? "Switch Vote" : "Vote"}
+                      </Button>
+                    )
                   )}
                 </div>
               </div>
@@ -487,18 +535,32 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
                 />
 
                 <div className="mt-5 flex justify-center">
-                  {resolvedStatus === "stage2" && (
-                    <Button
-                      className=" pointer-events-auto bg-green-300 hover:bg-green-400 text-gray-700 px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setSelectedBook(book2.concept_title);
-                        setSelectedSide("b");
-                        setIsVoting(true);
-                      }}
-                    >
-                      Vote
-                    </Button>
+                  {resolvedStatus === "stage2" && matchRound === activeRound && (
+                    userVote === "b" ? (
+                      <Button
+                        className="pointer-events-auto bg-red-500 hover:bg-red-600 text-white px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedBook(book2.concept_title);
+                          setSelectedSide("b");
+                          setIsVoting(true);
+                        }}
+                      >
+                        Cancel Vote
+                      </Button>
+                    ) : (
+                      <Button
+                        className="pointer-events-auto bg-green-300 hover:bg-green-400 text-gray-700 px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedBook(book2.concept_title);
+                          setSelectedSide("b");
+                          setIsVoting(true);
+                        }}
+                      >
+                        {userVote === "a" ? "Switch Vote" : "Vote"}
+                      </Button>
+                    )
                   )}
 
                 </div>
@@ -524,13 +586,19 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
           {/* dialog for voting */}
           <Dialog open={isVoting} onOpenChange={setIsVoting}>
-            <DialogContent className="max-w-sm rounded-2xl">
+            <DialogContent className="max-w-sm rounded-2xl animate-in fade-in-50 zoom-in-95 duration-200">
 
               <DialogHeader>
-                <DialogTitle className="text-[#1d2436]">Confirm Your Vote</DialogTitle>
+                <DialogTitle className="text-[#1d2436]">
+                  {userVote === selectedSide
+                    ? "Cancel Your Vote"
+                    : userVote && userVote !== selectedSide
+                      ? "Switch Your Vote"
+                      : "Confirm Your Vote"}
+                </DialogTitle>
                 <DialogDescription className="text-[#8088a0]">
                   {userVote === selectedSide
-                    ? `You have already voted for ${selectedBook}.`
+                    ? `Are you sure you want to cancel your vote for ${selectedBook}?`
                     : userVote && userVote !== selectedSide
                       ? `Would you like to switch your vote to ${selectedBook}?`
                       : `Would you like to vote for ${selectedBook}?`}
@@ -538,7 +606,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
                 </DialogDescription>
               </DialogHeader>
               <DialogFooter className="gap-2 sm:gap-2">
-                <Button onClick={() => setIsVoting(false)} disabled={isSubmittingVote}>
+                <Button onClick={() => setIsVoting(false)} variant="outline" disabled={isSubmittingVote}>
                   Cancel
                 </Button>
                 <Button onClick={handleConfirmVote} disabled={isSubmittingVote}>
@@ -549,10 +617,10 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
           </Dialog>
 
           {voteSuccess && (
-            <div className="fixed top-10 left-1/2 -translate-x-1/2 z-50">
+            <div className="fixed top-10 left-1/2 -translate-x-1/2 z-50 animate-in fade-in slide-in-from-top-4 duration-300">
               <Alert className="border-green-200 bg-green-100 shadow-lg px-6 py-4 w-fit">
                 <AlertDescription className="text-green-800 font-medium">
-                  ✓ Your vote for <span className="font-bold">{hasVoted}</span> has been submitted!
+                  {successMessage}
                 </AlertDescription>
               </Alert>
             </div>

--- a/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
@@ -60,6 +60,8 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
   const [book1Flipped, setBook1Flipped] = useState(false);
   const [book2Flipped, setBook2Flipped] = useState(false);
+  const [book1HasBeenFlipped, setBook1HasBeenFlipped] = useState(false);
+  const [book2HasBeenFlipped, setBook2HasBeenFlipped] = useState(false);
 
 
 
@@ -447,13 +449,17 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
                   alt={book1.concept_title}
                   className="w-full flex-1 min-h-0 rounded-lg shadow-md cursor-pointer aspect-[3/4]"
-                  onClick={() => setBook1Flipped(!book1Flipped)}
+                  onClick={() => { setBook1Flipped(!book1Flipped); setBook1HasBeenFlipped(true); }}
                 />
 
 
-                <div className="mt-5 flex justify-center">
+                <div className="mt-5 flex justify-center min-h-[48px] items-center">
                   {resolvedStatus === "stage2" && matchRound === activeRound && (
-                    userVote === "a" ? (
+                    !(book1HasBeenFlipped && book2HasBeenFlipped) ? (
+                      <span className="text-red-500 font-semibold text-sm animate-pulse">
+                        Flip both books to cast your vote
+                      </span>
+                    ) : userVote === "a" ? (
                       <Button
                         className="pointer-events-auto bg-red-500 hover:bg-red-600 text-white px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
                         onClick={(e) => {
@@ -484,7 +490,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
               {/* Back */}
               <div
-                onClick={() => setBook1Flipped(!book1Flipped)}
+                onClick={() => { setBook1Flipped(!book1Flipped); setBook1HasBeenFlipped(true); }}
                 className="absolute inset-0 overflow-hidden rounded-[1.75rem] p-6 bg-purple-100 cursor-pointer hover:bg-purple-200 shadow-md flex flex-col [transform:rotateY(180deg)] [backface-visibility:hidden]"
               >
                 <h2 className="text-2xl font-bold text-gray-800">
@@ -531,12 +537,16 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
                   alt={book2.concept_title}
                   className="w-full flex-1 min-h-0 rounded-lg shadow-md cursor-pointer aspect-[3/4]"
-                  onClick={() => setBook2Flipped(!book2Flipped)}
+                  onClick={() => { setBook2Flipped(!book2Flipped); setBook2HasBeenFlipped(true); }}
                 />
 
-                <div className="mt-5 flex justify-center">
+                <div className="mt-5 flex justify-center min-h-[48px] items-center">
                   {resolvedStatus === "stage2" && matchRound === activeRound && (
-                    userVote === "b" ? (
+                    !(book1HasBeenFlipped && book2HasBeenFlipped) ? (
+                      <span className="text-red-500 font-semibold text-sm animate-pulse">
+                        Flip both books to cast your vote
+                      </span>
+                    ) : userVote === "b" ? (
                       <Button
                         className="pointer-events-auto bg-red-500 hover:bg-red-600 text-white px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
                         onClick={(e) => {
@@ -568,7 +578,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
               {/* Back */}
               <div
-                onClick={() => setBook2Flipped(!book2Flipped)}
+                onClick={() => { setBook2Flipped(!book2Flipped); setBook2HasBeenFlipped(true); }}
                 className="absolute inset-0 overflow-hidden rounded-[1.75rem] p-6 bg-purple-100 cursor-pointer hover:bg-purple-200 shadow-md flex flex-col [transform:rotateY(180deg)] [backface-visibility:hidden]"
               >
 

--- a/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
@@ -74,6 +74,8 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
   const [book1, setBook1] = useState<Concept | null>(null);
   const [book2, setBook2] = useState<Concept | null>(null);
+  const [book1IsDeleted, setBook1IsDeleted] = useState(false);
+  const [book2IsDeleted, setBook2IsDeleted] = useState(false);
   const [submissionAId, setSubmissionAId] = useState<string | null>(null);
   const [submissionBId, setSubmissionBId] = useState<string | null>(null);
 
@@ -142,32 +144,47 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
       setTournament(tournamentData);
       if (tournamentData?.tournament_status) setTournamentStatus(tournamentData.tournament_status);
 
+      // Fetch submissions without filtering deleted — we need to detect deleted ones
       const { data: submissions, error: subError } = await supabase
         .from("tournament_submission")
-        .select("tournamentsub_id, concept_id")
-        .in("tournamentsub_id", [match.bmatch_submission_a, match.bmatch_submission_b])
-        .not("tournamentsub_status", "eq", "deleted");
+        .select("tournamentsub_id, concept_id, tournamentsub_status")
+        .in("tournamentsub_id", [match.bmatch_submission_a, match.bmatch_submission_b]);
 
       if (subError) throw subError;
 
-      const conceptIds = submissions.map((sub) => sub.concept_id);
+      const subA = submissions?.find((sub) => sub.tournamentsub_id === match.bmatch_submission_a);
+      const subB = submissions?.find((sub) => sub.tournamentsub_id === match.bmatch_submission_b);
 
-      const { data: concepts, error: conceptError } = await supabase
-        .from("concept")
-        .select("*")
-        .in("concept_id", conceptIds)
-        .not("concept_status", "eq", "deleted");
+      const subADeleted = !subA || subA.tournamentsub_status === 'deleted' || subA.tournamentsub_status === 'terminated';
+      const subBDeleted = !subB || subB.tournamentsub_status === 'deleted' || subB.tournamentsub_status === 'terminated';
 
-      if (conceptError) throw conceptError;
+      // Only fetch concepts for non-deleted submissions
+      const validConceptIds = [
+        !subADeleted ? subA!.concept_id : null,
+        !subBDeleted ? subB!.concept_id : null,
+      ].filter(Boolean) as string[];
 
-      const subA = submissions.find((sub) => sub.tournamentsub_id === match.bmatch_submission_a);
-      const subB = submissions.find((sub) => sub.tournamentsub_id === match.bmatch_submission_b);
+      let concepts: any[] = [];
+      if (validConceptIds.length > 0) {
+        const { data: conceptData, error: conceptError } = await supabase
+          .from("concept")
+          .select("*")
+          .in("concept_id", validConceptIds);
+        if (conceptError) throw conceptError;
+        concepts = conceptData ?? [];
+      }
 
-      const bookA = concepts.find((concept) => concept.concept_id === subA?.concept_id);
-      const bookB = concepts.find((concept) => concept.concept_id === subB?.concept_id);
+      const bookA = !subADeleted ? concepts.find((c) => c.concept_id === subA!.concept_id) ?? null : null;
+      const bookB = !subBDeleted ? concepts.find((c) => c.concept_id === subB!.concept_id) ?? null : null;
 
-      setBook1(bookA ?? null);
-      setBook2(bookB ?? null);
+      // A book is "deleted" if its sub is deleted/terminated OR its concept couldn't be fetched
+      const aIsDeleted = subADeleted || (!subADeleted && bookA === null);
+      const bIsDeleted = subBDeleted || (!subBDeleted && bookB === null);
+
+      setBook1(bookA);
+      setBook2(bookB);
+      setBook1IsDeleted(aIsDeleted);
+      setBook2IsDeleted(bIsDeleted);
       setSubmissionAId(subA?.tournamentsub_id ?? null);
       setSubmissionBId(subB?.tournamentsub_id ?? null);
     } catch (error) {
@@ -353,7 +370,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
 
   if (loading) return <p>Loading matchup...</p>;
-  if (!book1 || !book2) return <p>No matchup found.</p>;
+  if (!book1 && !book2 && !book1IsDeleted && !book2IsDeleted) return <p>No matchup found.</p>;
 
   return (
 
@@ -428,7 +445,17 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
         <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] gap-6 mt-6 items-center justify-items-center">
           {/* book 1 item */}
-
+          {book1IsDeleted ? (
+            <div className="perspective-[1000px] w-[400px]">
+              <div className="relative aspect-[3/4] w-full">
+                <div className="absolute inset-0 overflow-hidden rounded-lg p-6 bg-gray-100 border-2 border-dashed border-gray-300 shadow-sm flex flex-col items-center justify-center gap-3">
+                  <span className="text-5xl">📕</span>
+                  <p className="text-gray-500 font-semibold text-center">Book Unavailable</p>
+                  <p className="text-gray-400 text-sm text-center">This book was removed from the tournament.</p>
+                </div>
+              </div>
+            </div>
+          ) : (
           <div className="perspective-[1000px] w-[400px]">
             <div
               className={`relative aspect-[3/4] w-full transition-transform duration-500 [transform-style:preserve-3d] ${book1Flipped ? "[transform:rotateY(180deg)]" : "hover:-translate-y-3"}`}
@@ -439,15 +466,15 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
                 className="absolute inset-0 overflow-hidden rounded-lg p-4 bg-purple-100  hover:bg-purple-200 shadow-md flex flex-col [backface-visibility:hidden]"
               >
                 <img
-                  src={book1.concept_styling?.book_cover
+                  src={book1!.concept_styling?.book_cover
                     ? supabase.storage
                       .from("book-covers")
-                      .getPublicUrl(book1.concept_styling.book_cover)
+                      .getPublicUrl(book1!.concept_styling.book_cover)
                       .data.publicUrl
                     : "/placeholder-cover.png"
                   }
 
-                  alt={book1.concept_title}
+                  alt={book1!.concept_title}
                   className="w-full flex-1 min-h-0 rounded-lg shadow-md cursor-pointer aspect-[3/4]"
                   onClick={() => { setBook1Flipped(!book1Flipped); setBook1HasBeenFlipped(true); }}
                 />
@@ -464,7 +491,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
                         className="pointer-events-auto bg-red-500 hover:bg-red-600 text-white px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
                         onClick={(e) => {
                           e.stopPropagation();
-                          setSelectedBook(book1.concept_title);
+                          setSelectedBook(book1!.concept_title);
                           setSelectedSide("a");
                           setIsVoting(true);
                         }}
@@ -476,7 +503,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
                         className="pointer-events-auto bg-green-300 hover:bg-green-400 text-gray-700 px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
                         onClick={(e) => {
                           e.stopPropagation();
-                          setSelectedBook(book1.concept_title);
+                          setSelectedBook(book1!.concept_title);
                           setSelectedSide("a");
                           setIsVoting(true);
                         }}
@@ -494,16 +521,17 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
                 className="absolute inset-0 overflow-hidden rounded-[1.75rem] p-6 bg-purple-100 cursor-pointer hover:bg-purple-200 shadow-md flex flex-col [transform:rotateY(180deg)] [backface-visibility:hidden]"
               >
                 <h2 className="text-2xl font-bold text-gray-800">
-                  {book1.concept_title}
+                  {book1!.concept_title}
                 </h2>
 
                 <p className="text-base text-gray-700 leading-relaxed overflow-y-auto">
-                  {book1.concept_description}
+                  {book1!.concept_description}
                 </p>
 
               </div>
             </div>
           </div>
+          )}
 
           {/* end of book1 item */}
 
@@ -515,7 +543,17 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
           </div>
 
           {/* Book 2 item */}
-
+          {book2IsDeleted ? (
+            <div className="perspective-[1000px] w-[400px]">
+              <div className="relative aspect-[3/4] w-full">
+                <div className="absolute inset-0 overflow-hidden rounded-lg p-6 bg-gray-100 border-2 border-dashed border-gray-300 shadow-sm flex flex-col items-center justify-center gap-3">
+                  <span className="text-5xl">📕</span>
+                  <p className="text-gray-500 font-semibold text-center">Book Unavailable</p>
+                  <p className="text-gray-400 text-sm text-center">This book was removed from the tournament.</p>
+                </div>
+              </div>
+            </div>
+          ) : (
           <div className="perspective-[1000px] w-[400px]">
             <div
               className={`relative aspect-[3/4] w-full transition-transform duration-500 [transform-style:preserve-3d] ${book2Flipped ? "[transform:rotateY(180deg)]" : "hover:-translate-y-3"}`}
@@ -527,15 +565,15 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
                 className="absolute inset-0 overflow-hidden rounded-lg p-4 bg-purple-100 hover:bg-purple-200 shadow-md flex flex-col [backface-visibility:hidden]"
               >
                 <img
-                  src={book2.concept_styling?.book_cover
+                  src={book2!.concept_styling?.book_cover
                     ? supabase.storage
                       .from("book-covers")
-                      .getPublicUrl(book2.concept_styling.book_cover)
+                      .getPublicUrl(book2!.concept_styling.book_cover)
                       .data.publicUrl
                     : "/placeholder-cover.png"
                   }
 
-                  alt={book2.concept_title}
+                  alt={book2!.concept_title}
                   className="w-full flex-1 min-h-0 rounded-lg shadow-md cursor-pointer aspect-[3/4]"
                   onClick={() => { setBook2Flipped(!book2Flipped); setBook2HasBeenFlipped(true); }}
                 />
@@ -551,7 +589,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
                         className="pointer-events-auto bg-red-500 hover:bg-red-600 text-white px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
                         onClick={(e) => {
                           e.stopPropagation();
-                          setSelectedBook(book2.concept_title);
+                          setSelectedBook(book2!.concept_title);
                           setSelectedSide("b");
                           setIsVoting(true);
                         }}
@@ -563,7 +601,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
                         className="pointer-events-auto bg-green-300 hover:bg-green-400 text-gray-700 px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
                         onClick={(e) => {
                           e.stopPropagation();
-                          setSelectedBook(book2.concept_title);
+                          setSelectedBook(book2!.concept_title);
                           setSelectedSide("b");
                           setIsVoting(true);
                         }}
@@ -583,16 +621,17 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
               >
 
                 <h2 className="text-2xl font-bold text-gray-800">
-                  {book2.concept_title}
+                  {book2!.concept_title}
                 </h2>
 
                 <p className="text-base text-gray-700 leading-relaxed overflow-y-auto">
-                  {book2.concept_description}
+                  {book2!.concept_description}
                 </p>
 
               </div>
             </div>
           </div>
+          )}
 
           {/* dialog for voting */}
           <Dialog open={isVoting} onOpenChange={setIsVoting}>

--- a/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
@@ -8,6 +8,7 @@ import { Concept } from "@/app/_types/model/Concept";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   formatCountdownParts,
+  formatStatusLabel,
   getCountdownParts,
   getRoundCountdownTarget,
   getTournamentMilestoneTarget,
@@ -351,7 +352,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
           <div className={`rounded-full px-5 py-3 text-sm font-semibold shadow-lg mb-3 ${resolvedStatus === "stage2" ? "bg-green-100 text-blue-800" : "bg-slate-100 text-slate-700"}`}>
             {resolvedStatus === "stage2"
-              ? `Voting ends in ${formatCountdownParts(totalCountdown)}`
+              ? `Round ${activeRound} voting ends in ${formatCountdownParts(roundCountdown)}`
               : resolvedStatus === "stage1"
                 ? `Stage 2 starts in ${formatCountdownParts(milestoneCountdown)}`
                 : resolvedStatus === "upcoming"
@@ -361,7 +362,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
         </div>
         <div className="mt-3 flex flex-wrap items-center gap-3">
           <span className="rounded-full bg-purple-100 px-4 py-2 text-sm font-bold text-purple-800">
-            {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)}
+            {formatStatusLabel(resolvedStatus, activeRound)}
           </span>
           <span className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm">
             Round {activeRound} of {totalRounds}
@@ -372,13 +373,13 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
         {resolvedStatus !== "concluded" && resolvedStatus !== "terminated" && (
           <div className="mt-6 grid gap-4 md:grid-cols-2">
             <div className="rounded-3xl border border-purple-200 bg-purple-50 p-5 shadow-sm">
-              <p className="text-xs font-black uppercase tracking-[0.16em] text-purple-700">Tournament time remaining</p>
+              <p className="text-xs font-black uppercase tracking-[0.16em] text-purple-700">Tournament ends in</p>
               <p className="mt-3 text-3xl font-extrabold text-purple-900">{formatCountdownParts(totalCountdown)}</p>
             </div>
 
             {resolvedStatus === "stage2" && (
               <div className="rounded-3xl border border-emerald-200 bg-emerald-50 p-5 shadow-sm">
-                <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Current round time remaining</p>
+                <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Round {activeRound} voting ends</p>
                 <p className="mt-3 text-3xl font-extrabold text-emerald-900">{formatCountdownParts(roundCountdown)}</p>
               </div>
             )}

--- a/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
@@ -369,19 +369,21 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
         </div>
         <p className="mb-2 max-w-4xl text-base font-bold text-gray-500 sm:text-xl pt-3">{bracket?.bracket_round_number} One vs One</p>
 
-        <div className="mt-6 grid gap-4 md:grid-cols-2">
-          <div className="rounded-3xl border border-purple-200 bg-purple-50 p-5 shadow-sm">
-            <p className="text-xs font-black uppercase tracking-[0.16em] text-purple-700">Tournament time remaining</p>
-            <p className="mt-3 text-3xl font-extrabold text-purple-900">{formatCountdownParts(totalCountdown)}</p>
-          </div>
-
-          {resolvedStatus === "stage2" && (
-            <div className="rounded-3xl border border-emerald-200 bg-emerald-50 p-5 shadow-sm">
-              <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Current round time remaining</p>
-              <p className="mt-3 text-3xl font-extrabold text-emerald-900">{formatCountdownParts(roundCountdown)}</p>
+        {resolvedStatus !== "concluded" && resolvedStatus !== "terminated" && (
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            <div className="rounded-3xl border border-purple-200 bg-purple-50 p-5 shadow-sm">
+              <p className="text-xs font-black uppercase tracking-[0.16em] text-purple-700">Tournament time remaining</p>
+              <p className="mt-3 text-3xl font-extrabold text-purple-900">{formatCountdownParts(totalCountdown)}</p>
             </div>
-          )}
-        </div>
+
+            {resolvedStatus === "stage2" && (
+              <div className="rounded-3xl border border-emerald-200 bg-emerald-50 p-5 shadow-sm">
+                <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Current round time remaining</p>
+                <p className="mt-3 text-3xl font-extrabold text-emerald-900">{formatCountdownParts(roundCountdown)}</p>
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Book section */}
 

--- a/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/[bmatchid]/onevsone/_components/OneVsOnePage.tsx
@@ -2,10 +2,18 @@
 
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { Concept } from "@/app/_types/model/Concept";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  formatCountdownParts,
+  getCountdownParts,
+  getRoundCountdownTarget,
+  getTournamentMilestoneTarget,
+  resolveTournamentLifecycleStatus,
+  TournamentLifecycleStatus,
+} from "@/app/_utilities/tournamentLifecycle";
 
 import {
   Dialog,
@@ -25,12 +33,15 @@ type Props = {
 
 type Bracket = {
   bracket_round_number: number;
+  bracket_status?: string;
 };
 
 type Tournament = {
   tournament_title: string;
+  tournament_start_date: string;
+  tournament_s2_start_date: string | null;
   tournament_end_date: string;
-  tournament_status?: string;
+  tournament_status: string;
 };
 
 const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
@@ -53,6 +64,8 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
   const [tournament, setTournament] = useState<Tournament | null>(null);
   const [tournamentStatus, setTournamentStatus] = useState<string | null>(null);
   const [bracket, setBracket] = useState<Bracket | null>(null);
+  const [totalRounds, setTotalRounds] = useState(1);
+  const [activeRound, setActiveRound] = useState(1);
 
   const [book1, setBook1] = useState<Concept | null>(null);
   const [book2, setBook2] = useState<Concept | null>(null);
@@ -60,106 +73,120 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
   const [submissionBId, setSubmissionBId] = useState<string | null>(null);
 
   const [loading, setLoading] = useState(true);
+  const [now, setNow] = useState(() => Date.now());
 
   const hasVoted = userVote === "a" ? book1?.concept_title : userVote === "b" ? book2?.concept_title : null;
 
-  useEffect(() => {
-
-    const fetchMatchup = async () => {
-      setLoading(true);
+  const fetchMatchup = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
+    try {
       try {
-        // 1. Fetch the match
-        const { data: match, error: matchError } = await supabase
-          .from("bracket_match")
-          .select("*")
-          .eq("bmatch_id", bmatchId)
-          .single();
-
-        if (matchError) throw matchError;
-
-        // 2. Fetch the bracket and validate tournament_id matches the URL
-        const { data: bracketData, error: bracketError } = await supabase
-          .from("bracket")
-          .select("bracket_round_number, tournament_id")
-          .eq("bracket_id", match.bracket_id)
-          .single();
-
-        if (bracketError) throw bracketError;
-
-        if (String(bracketData.tournament_id) !== String(tournamentId)) {
-          router.push(`/tournament/${tournamentId}/tournamentbracket`);
-          return;
-        }
-
-        setBracket(bracketData);
-
-        // 3. Fetch tournament data
-        const { data: tournamentData, error: tournamentError } = await supabase
-          .from("tournament")
-          .select("tournament_title, tournament_end_date, tournament_status")
-          .eq("tournament_id", bracketData.tournament_id)
-          .single();
-
-        if (tournamentError) throw tournamentError;
-        setTournament(tournamentData);
-        if (tournamentData?.tournament_status) setTournamentStatus(tournamentData.tournament_status);
-
-        // 4. Fetch submissions
-        const { data: submissions, error: subError } = await supabase
-          .from("tournament_submission")
-          .select("tournamentsub_id, concept_id")
-          .in("tournamentsub_id", [
-            match.bmatch_submission_a,
-            match.bmatch_submission_b,
-          ])
-          .not("tournamentsub_status", "eq", "deleted");
-
-        if (subError) throw subError;
-
-        const conceptIds = submissions.map((sub) => sub.concept_id);
-
-        // 5. Fetch concepts
-        const { data: concepts, error: conceptError } = await supabase
-          .from("concept")
-          .select("*")
-          .in("concept_id", conceptIds)
-          .not("concept_status", "eq", "deleted");
-
-        if (conceptError) throw conceptError;
-
-
-        const subA = submissions.find(
-          (sub) => sub.tournamentsub_id === match.bmatch_submission_a
-        );
-        const subB = submissions.find(
-          (sub) => sub.tournamentsub_id === match.bmatch_submission_b
-        );
-
-        const bookA = concepts.find(
-          (concept) => concept.concept_id === subA?.concept_id
-        );
-        const bookB = concepts.find(
-          (concept) => concept.concept_id === subB?.concept_id
-        );
-
-        setBook1(bookA ?? null);
-        setBook2(bookB ?? null);
-        setSubmissionAId(subA?.tournamentsub_id ?? null);
-        setSubmissionBId(subB?.tournamentsub_id ?? null);
-
-
-
-      } catch (error) {
-        console.error("Fetch matchup failed:", error);
-        router.push(`/tournament/${tournamentId}/tournamentbracket`);
-      } finally {
-        setLoading(false);
+        await supabase.rpc("advance_tournament_lifecycle", { p_tournament_id: Number(tournamentId) });
+      } catch (e) {
+        console.warn("Lifecycle update check failed:", e);
       }
-    };
 
+      const { data: match, error: matchError } = await supabase
+        .from("bracket_match")
+        .select("*")
+        .eq("bmatch_id", bmatchId)
+        .single();
 
-    fetchMatchup();
+      if (matchError) throw matchError;
+
+      const { data: bracketData, error: bracketError } = await supabase
+        .from("bracket")
+        .select("bracket_id, bracket_round_number, tournament_id, bracket_status")
+        .eq("bracket_id", match.bracket_id)
+        .single();
+
+      if (bracketError) throw bracketError;
+
+      if (String(bracketData.tournament_id) !== String(tournamentId)) {
+        router.push(`/tournament/${tournamentId}/tournamentbracket`);
+        return;
+      }
+
+      setBracket(bracketData);
+
+      const { data: bracketMatches, error: matchesError } = await supabase
+        .from("bracket_match")
+        .select("bmatch_index")
+        .eq("bracket_id", bracketData.bracket_id);
+
+      const r1Count = (bracketMatches ?? []).filter(
+        (m: any) => (m.bmatch_index?.round ?? 1) === 1
+      ).length;
+      const computedTotalRounds = Math.max(1, Math.ceil(Math.log2(r1Count * 2)));
+      const computedActiveRound = bracketData.bracket_round_number ?? 1;
+
+      setTotalRounds(computedTotalRounds);
+      setActiveRound(computedActiveRound);
+
+      const { data: tournamentData, error: tournamentError } = await supabase
+        .from("tournament")
+        .select("tournament_title, tournament_start_date, tournament_s2_start_date, tournament_end_date, tournament_status")
+        .eq("tournament_id", bracketData.tournament_id)
+        .single();
+
+      if (tournamentError) throw tournamentError;
+      setTournament(tournamentData);
+      if (tournamentData?.tournament_status) setTournamentStatus(tournamentData.tournament_status);
+
+      const { data: submissions, error: subError } = await supabase
+        .from("tournament_submission")
+        .select("tournamentsub_id, concept_id")
+        .in("tournamentsub_id", [match.bmatch_submission_a, match.bmatch_submission_b])
+        .not("tournamentsub_status", "eq", "deleted");
+
+      if (subError) throw subError;
+
+      const conceptIds = submissions.map((sub) => sub.concept_id);
+
+      const { data: concepts, error: conceptError } = await supabase
+        .from("concept")
+        .select("*")
+        .in("concept_id", conceptIds)
+        .not("concept_status", "eq", "deleted");
+
+      if (conceptError) throw conceptError;
+
+      const subA = submissions.find((sub) => sub.tournamentsub_id === match.bmatch_submission_a);
+      const subB = submissions.find((sub) => sub.tournamentsub_id === match.bmatch_submission_b);
+
+      const bookA = concepts.find((concept) => concept.concept_id === subA?.concept_id);
+      const bookB = concepts.find((concept) => concept.concept_id === subB?.concept_id);
+
+      setBook1(bookA ?? null);
+      setBook2(bookB ?? null);
+      setSubmissionAId(subA?.tournamentsub_id ?? null);
+      setSubmissionBId(subB?.tournamentsub_id ?? null);
+    } catch (error) {
+      console.error("Fetch matchup failed:", error);
+      router.push(`/tournament/${tournamentId}/tournamentbracket`);
+    } finally {
+      if (!silent) setLoading(false);
+    }
   }, [bmatchId, tournamentId, router]);
+
+  useEffect(() => {
+    fetchMatchup();
+  }, [fetchMatchup]);
+
+  useEffect(() => {
+    const timerId = window.setInterval(() => setNow(Date.now()), 15000);
+    return () => window.clearInterval(timerId);
+  }, []);
+
+  useEffect(() => {
+    if (!tournament) return;
+
+    const timerId = window.setInterval(() => {
+      fetchMatchup(true);
+    }, 30000);
+
+    return () => window.clearInterval(timerId);
+  }, [fetchMatchup, tournament]);
 
 
 
@@ -199,18 +226,32 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
   }, [submissionAId, submissionBId, bmatchId]);
   //________________helpers________________________________________________________
 
+  const resolvedStatus = useMemo<TournamentLifecycleStatus>(() => {
+    return resolveTournamentLifecycleStatus(tournament, now);
+  }, [now, tournament]);
 
-  const calculateTimeLeft = (endDate: string) => {
-    const difference = new Date(endDate).getTime() - new Date().getTime();
+  const totalCountdown = useMemo(() => {
+    return getCountdownParts(
+      tournament?.tournament_end_date ? new Date(tournament.tournament_end_date).getTime() : null,
+      now,
+    );
+  }, [now, tournament?.tournament_end_date]);
 
-    if (difference <= 0) return "Voting ended";
+  const milestone = useMemo(() => {
+    return getTournamentMilestoneTarget(tournament, resolvedStatus);
+  }, [resolvedStatus, tournament]);
 
-    const days = Math.floor(difference / (1000 * 60 * 60 * 24));
-    const hours = Math.floor((difference / (1000 * 60 * 60)) % 24);
-    const minutes = Math.floor((difference / (1000 * 60)) % 60);
+  const milestoneCountdown = useMemo(() => {
+    return getCountdownParts(milestone.targetMs, now);
+  }, [milestone.targetMs, now]);
 
-    return `${days}d ${hours}h ${minutes}m`;
-  };
+  const roundCountdownTarget = useMemo(() => {
+    return getRoundCountdownTarget(tournament, totalRounds, activeRound);
+  }, [activeRound, totalRounds, tournament]);
+
+  const roundCountdown = useMemo(() => {
+    return getCountdownParts(roundCountdownTarget, now);
+  }, [now, roundCountdownTarget]);
 
 
 
@@ -229,7 +270,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
     }
 
     // Prevent voting unless the tournament is in stage2
-    if (tournamentStatus !== "stage2") {
+    if (resolvedStatus !== "stage2") {
       alert("Voting is not open for this tournament.");
       setIsVoting(false);
       return;
@@ -308,13 +349,39 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
           <h1 className=" md:text-5xl font-headline font-bold text-on-surface tracking-tighter pt-3 ">
             {tournament?.tournament_title}</h1>
 
-          <div className="rounded-full bg-green-100 px-5 py-3 text-sm font-semibold text-blue-800 shadow-lg mb-3 ">
-            {calculateTimeLeft(tournament ? tournament.tournament_end_date : "") === "Voting ended"
-              ? "Voting has ended"
-              : `Voting Ends in ${calculateTimeLeft(tournament ? tournament.tournament_end_date : "")}`}
+          <div className={`rounded-full px-5 py-3 text-sm font-semibold shadow-lg mb-3 ${resolvedStatus === "stage2" ? "bg-green-100 text-blue-800" : "bg-slate-100 text-slate-700"}`}>
+            {resolvedStatus === "stage2"
+              ? `Voting ends in ${formatCountdownParts(totalCountdown)}`
+              : resolvedStatus === "stage1"
+                ? `Stage 2 starts in ${formatCountdownParts(milestoneCountdown)}`
+                : resolvedStatus === "upcoming"
+                  ? `Tournament starts in ${formatCountdownParts(milestoneCountdown)}`
+                  : "Voting has ended"}
           </div>
         </div>
-        <p className="mb-2 max-w-4xl text-base font-bold text-gray-500 sm:text-xl pt-3">Round: {bracket?.bracket_round_number} One vs One</p>
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <span className="rounded-full bg-purple-100 px-4 py-2 text-sm font-bold text-purple-800">
+            {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)}
+          </span>
+          <span className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm">
+            Round {activeRound} of {totalRounds}
+          </span>
+        </div>
+        <p className="mb-2 max-w-4xl text-base font-bold text-gray-500 sm:text-xl pt-3">{bracket?.bracket_round_number} One vs One</p>
+
+        <div className="mt-6 grid gap-4 md:grid-cols-2">
+          <div className="rounded-3xl border border-purple-200 bg-purple-50 p-5 shadow-sm">
+            <p className="text-xs font-black uppercase tracking-[0.16em] text-purple-700">Tournament time remaining</p>
+            <p className="mt-3 text-3xl font-extrabold text-purple-900">{formatCountdownParts(totalCountdown)}</p>
+          </div>
+
+          {resolvedStatus === "stage2" && (
+            <div className="rounded-3xl border border-emerald-200 bg-emerald-50 p-5 shadow-sm">
+              <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Current round time remaining</p>
+              <p className="mt-3 text-3xl font-extrabold text-emerald-900">{formatCountdownParts(roundCountdown)}</p>
+            </div>
+          )}
+        </div>
 
         {/* Book section */}
 
@@ -348,7 +415,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
 
 
                 <div className="mt-5 flex justify-center">
-                  {tournamentStatus === "stage2" && (
+                  {resolvedStatus === "stage2" && (
                     <Button
                       className="pointer-events-auto bg-green-300 hover:bg-green-400 text-gray-700 px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
                       onClick={(e) => {
@@ -417,7 +484,7 @@ const OneVsOnePage = ({ tournamentId, bmatchId }: Props) => {
                 />
 
                 <div className="mt-5 flex justify-center">
-                  {tournamentStatus === "stage2" && (
+                  {resolvedStatus === "stage2" && (
                     <Button
                       className=" pointer-events-auto bg-green-300 hover:bg-green-400 text-gray-700 px-10 py-5.5 text-lg rounded-[1.75rem] shadow-lg"
                       onClick={(e) => {

--- a/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
@@ -868,38 +868,52 @@ export default function TournamentBracketPage({
       </h1>
 
       {tournament && (
-        <div className="mb-6 grid gap-4 rounded-2xl border border-emerald-200 bg-gradient-to-r from-white to-emerald-50 p-5 shadow-sm lg:grid-cols-3">
-          <div>
-            <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Live tournament status</p>
-            <p className="mt-2 text-2xl font-black tracking-[-0.04em] text-[#1d2436]">
-              {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)}
-            </p>
-            <p className="mt-1 text-sm text-[#6b7490]">Auto-refreshes every 30s</p>
+        resolvedStatus === "concluded" || resolvedStatus === "terminated" ? (
+          <div className="mb-6 rounded-2xl border border-emerald-200 bg-gradient-to-r from-white to-emerald-50 p-5 shadow-sm flex items-center justify-between">
+            <div>
+              <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Tournament status</p>
+              <p className="mt-2 text-2xl font-black tracking-[-0.04em] text-[#1d2436]">
+                {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)}
+              </p>
+            </div>
+            <span className="rounded-full bg-emerald-100 px-4 py-2 text-xs font-bold uppercase tracking-[0.12em] text-emerald-700">
+              The tournament has finished
+            </span>
           </div>
+        ) : (
+          <div className="mb-6 grid gap-4 rounded-2xl border border-emerald-200 bg-gradient-to-r from-white to-emerald-50 p-5 shadow-sm lg:grid-cols-3">
+            <div>
+              <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Live tournament status</p>
+              <p className="mt-2 text-2xl font-black tracking-[-0.04em] text-[#1d2436]">
+                {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)}
+              </p>
+              <p className="mt-1 text-sm text-[#6b7490]">Auto-refreshes every 30s</p>
+            </div>
 
-          <div className="rounded-2xl bg-white px-4 py-4 shadow-sm">
-            <p className="text-xs font-black uppercase tracking-[0.16em] text-purple-700">Tournament ends in</p>
-            <p className="mt-2 text-xl font-extrabold text-purple-900">{formatCountdownParts(totalCountdown)}</p>
-          </div>
+            <div className="rounded-2xl bg-white px-4 py-4 shadow-sm">
+              <p className="text-xs font-black uppercase tracking-[0.16em] text-purple-700">Tournament ends in</p>
+              <p className="mt-2 text-xl font-extrabold text-purple-900">{formatCountdownParts(totalCountdown)}</p>
+            </div>
 
-          <div className="rounded-2xl bg-white px-4 py-4 shadow-sm">
-            <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">{milestone.label}</p>
-            <p className="mt-2 text-xl font-extrabold text-emerald-900">{formatCountdownParts(milestoneCountdown)}</p>
-            {resolvedStatus === "stage2" && (
-              <p className="mt-2 text-sm text-[#6b7490]">Current round remaining: {formatCountdownParts(roundCountdown)}</p>
-            )}
-            {isAdmin && (tournament.tournament_status === "stage1" || tournament.tournament_status === "stage2") && (
-              <div className="mt-3 flex gap-2">
-                {tournament.tournament_status === "stage1" && (
-                  <Button variant="outline" onClick={() => openConfirm("stage2")}>Advance to Stage 2 (seed now)</Button>
-                )}
-                {tournament.tournament_status === "stage2" && (
-                  <Button variant="outline" onClick={() => openConfirm("round")}>Advance to Round {activeRound + 1}</Button>
-                )}
-              </div>
-            )}
+            <div className="rounded-2xl bg-white px-4 py-4 shadow-sm">
+              <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">{milestone.label}</p>
+              <p className="mt-2 text-xl font-extrabold text-emerald-900">{formatCountdownParts(milestoneCountdown)}</p>
+              {resolvedStatus === "stage2" && (
+                <p className="mt-2 text-sm text-[#6b7490]">Current round remaining: {formatCountdownParts(roundCountdown)}</p>
+              )}
+              {isAdmin && (tournament.tournament_status === "stage1" || tournament.tournament_status === "stage2") && (
+                <div className="mt-3 flex gap-2">
+                  {tournament.tournament_status === "stage1" && (
+                    <Button variant="outline" onClick={() => openConfirm("stage2")}>Advance to Stage 2 (seed now)</Button>
+                  )}
+                  {tournament.tournament_status === "stage2" && (
+                    <Button variant="outline" onClick={() => openConfirm("round")}>Advance to Round {activeRound + 1}</Button>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )
       )}
 
       <BracketSVG

--- a/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
@@ -845,7 +845,7 @@ export default function TournamentBracketPage({
           .from("vote")
           .select("bmatch_id, tournamentsub_id")
           .eq("user_id", user.id);
-        
+
         if (voteRows) {
           const votesMap: Record<number, string> = {};
           voteRows.forEach((v) => {
@@ -960,7 +960,7 @@ export default function TournamentBracketPage({
   return (
     <div className="p-6">
       <h1 className="relative text-3xl font-bold tracking-tight text-center text-gray-900 mb-6">
-        Tournament Bracket
+        {tournament ? tournament.tournament_title : "Tournament Bracket"}
         <Button className="absolute left-0 bg-white hover:bg-slate-100 tracking-normal text-sm font-medium text-slate-700" onClick={() => { router.push("./") }}>
           ← Back to Tournament
         </Button>

--- a/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
@@ -87,7 +87,7 @@ function MatchTooltip({
   mouseX: number;
   mouseY: number;
   containerW: number;
-  userVotes: Set<string>;
+  userVotes: Record<number, string>;
 }) {
   const TOOLTIP_W = 360;
   const OFFSET = 16;
@@ -99,9 +99,10 @@ function MatchTooltip({
 
   const top = mouseY - 90;
 
-  const votedA = userVotes.has(match.tournamentSubAId);
-  const votedB = userVotes.has(match.tournamentSubBId);
-  const hasVoted = votedA || votedB;
+  const votedSubId = userVotes[match.id];
+  const votedA = votedSubId === match.tournamentSubAId;
+  const votedB = votedSubId === match.tournamentSubBId;
+  const hasVoted = !!votedSubId;
 
   return (
     <div
@@ -246,7 +247,7 @@ function BracketSVG({
   onMatchClick: (m: BracketMatch) => void;
   resolvedStatus: TournamentLifecycleStatus;
   activeRound: number | null;
-  userVotes: Set<string>;
+  userVotes: Record<number, string>;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [hoveredMatch, setHoveredMatch] = useState<BracketMatch | null>(null);
@@ -582,7 +583,7 @@ function BracketSVG({
     const isCompleted = m.status === "completed";
     const isHovered = hoveredMatch?.id === m.id;
 
-    const hasVoted = userVotes.has(m.tournamentSubAId) || userVotes.has(m.tournamentSubBId);
+    const hasVoted = !!userVotes[m.id];
     const dotColor = hasVoted ? "#3b82f6" : "#ef4444";
 
     cards.push(
@@ -664,7 +665,7 @@ export default function TournamentBracketPage({
   const [matches, setMatches] = useState<BracketMatch[]>([]);
   const [totalRounds, setTotalRounds] = useState(1);
   const [activeRound, setActiveRound] = useState(1);
-  const [userVotes, setUserVotes] = useState<Set<string>>(new Set());
+  const [userVotes, setUserVotes] = useState<Record<number, string>>({});
   const [tournament, setTournament] = useState<{
     tournament_id: number;
     tournament_title: string;
@@ -842,11 +843,17 @@ export default function TournamentBracketPage({
       if (user) {
         const { data: voteRows } = await supabase
           .from("vote")
-          .select("tournamentsub_id")
+          .select("bmatch_id, tournamentsub_id")
           .eq("user_id", user.id);
         
         if (voteRows) {
-          setUserVotes(new Set(voteRows.map((v) => v.tournamentsub_id)));
+          const votesMap: Record<number, string> = {};
+          voteRows.forEach((v) => {
+            if (v.bmatch_id) {
+              votesMap[v.bmatch_id] = v.tournamentsub_id;
+            }
+          });
+          setUserVotes(votesMap);
         }
       }
     } catch (err) {

--- a/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
@@ -5,6 +5,22 @@ import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import type { JSX } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  formatCountdownParts,
+  getCountdownParts,
+  getRoundCountdownTarget,
+  getTournamentMilestoneTarget,
+  resolveTournamentLifecycleStatus,
+  TournamentLifecycleStatus,
+} from "@/app/_utilities/tournamentLifecycle";
 
 // ----------------------------
 // CONSTANTS
@@ -568,165 +584,275 @@ export default function TournamentBracketPage({
 }) {
   const [matches, setMatches] = useState<BracketMatch[]>([]);
   const [totalRounds, setTotalRounds] = useState(1);
+  const [activeRound, setActiveRound] = useState(1);
+  const [tournament, setTournament] = useState<{
+    tournament_id: number;
+    tournament_title: string;
+    tournament_status: string;
+    tournament_start_date: string;
+    tournament_s2_start_date: string | null;
+    tournament_end_date: string;
+  } | null>(null);
+  const [now, setNow] = useState(() => Date.now());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<"stage2" | "round" | null>(null);
   const router = useRouter();
 
-  useEffect(() => {
-    async function load() {
-      setLoading(true);
-      setError(null);
+  const load = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
+    setError(null);
 
+    try {
       try {
-        // 1. Get bracket for this tournament
-        const { data: bracketRows, error: bracketError } = await supabase
-          .from("bracket")
-          .select("bracket_id")
-          .eq("tournament_id", Number(tournamentId));
-
-        if (bracketError || !bracketRows || !bracketRows.length) {
-          setError("No bracket found for this tournament.");
-          setLoading(false);
-          return;
-        }
-
-        const bracketId = bracketRows[0].bracket_id;
-
-        // 2. Get all bracket matches
-        const { data: rawMatches, error: matchError } = await supabase
-          .from("bracket_match")
-          .select("*")
-          .eq("bracket_id", bracketId);
-
-        if (matchError || !rawMatches || !rawMatches.length) {
-          setError("No matches found for this bracket.");
-          setLoading(false);
-          return;
-        }
-
-        // 3. Collect all tournamentsub_ids
-        const subIds = [
-          ...new Set(
-            [
-              ...rawMatches.map((m) => m.bmatch_submission_a),
-              ...rawMatches.map((m) => m.bmatch_submission_b),
-            ].filter(Boolean)
-          ),
-        ];
-
-        // 4. Resolve submission → concept (name, cover, description)
-        const { data: subs } = await supabase
-          .from("tournament_submission")
-          .select("tournamentsub_id, concept(concept_title, concept_description, concept_styling)")
-          .in("tournamentsub_id", subIds);
-
-        const nameMap: Record<string, string> = {};
-        const coverMap: Record<string, string | null> = {};
-        const descMap: Record<string, string | null> = {};
-
-        (subs ?? []).forEach((s: any) => {
-          const c = s.concept;
-          if (!c) return;
-          nameMap[s.tournamentsub_id] = c.concept_title ?? "TBD";
-          descMap[s.tournamentsub_id] = c.concept_description ?? null;
-          coverMap[s.tournamentsub_id] = c.concept_styling?.book_cover ?? null;
-        });
-
-        // 5. Sort by round then slot
-        const sorted = [...rawMatches].sort((a, b) => {
-          const ar = a.bmatch_index?.round ?? 1;
-          const br = b.bmatch_index?.round ?? 1;
-          const as = a.bmatch_index?.slot ?? 1;
-          const bs = b.bmatch_index?.slot ?? 1;
-          return ar !== br ? ar - br : as - bs;
-        });
-
-        // 6. Total rounds from round 1 count
-        const r1Count = sorted.filter((m) => (m.bmatch_index?.round ?? 1) === 1).length;
-        const computedTotalRounds = Math.max(1, Math.ceil(Math.log2(r1Count * 2)));
-        setTotalRounds(computedTotalRounds);
-
-        // 7. Group by round
-        const uniqueRounds = [
-          ...new Set(sorted.map((m) => m.bmatch_index?.round ?? 1)),
-        ].sort((a, b) => a - b);
-
-        const byRound: Record<number, typeof sorted> = {};
-        sorted.forEach((m) => {
-          const r = m.bmatch_index?.round ?? 1;
-          if (!byRound[r]) byRound[r] = [];
-          byRound[r].push(m);
-        });
-
-        const r1Matches = byRound[1] ?? [];
-        const r1Half = Math.ceil(r1Matches.length / 2);
-        const finalRound = uniqueRounds.length > 1 ? uniqueRounds[uniqueRounds.length - 1] : null;
-
-        // 8. Build BracketMatch[]
-        const built: BracketMatch[] = sorted.map((m) => {
-          const round = m.bmatch_index?.round ?? 1;
-          const roundMatches = byRound[round] ?? [];
-          const indexInRound = roundMatches.findIndex((x) => x.bmatch_id === m.bmatch_id);
-
-          let side: "left" | "right" | "final" = "left";
-          if (round === finalRound) {
-            side = "final";
-          } else if (round === 1) {
-            side = indexInRound < r1Half ? "left" : "right";
-          } else {
-            side = indexInRound < roundMatches.length / 2 ? "left" : "right";
-          }
-
-          const nextRoundIdx = uniqueRounds.indexOf(round) + 1;
-          const nextRound = uniqueRounds[nextRoundIdx];
-          const nextRoundMatches = nextRound ? byRound[nextRound] : null;
-          const nextMatch = nextRoundMatches?.[Math.floor(indexInRound / 2)] ?? null;
-
-          return {
-            id: m.bmatch_id,
-            bmatchId: String(m.bmatch_id),
-            roundNumber: round,
-            slot: m.bmatch_index?.slot ?? 1,
-            nameA: nameMap[m.bmatch_submission_a] ?? "TBD",
-            nameB: nameMap[m.bmatch_submission_b] ?? "TBD",
-            coverA: coverMap[m.bmatch_submission_a] ?? null,
-            coverB: coverMap[m.bmatch_submission_b] ?? null,
-            descA: descMap[m.bmatch_submission_a] ?? null,
-            descB: descMap[m.bmatch_submission_b] ?? null,
-            status: m.bmatch_status ?? "active",
-            side,
-            indexInRound,
-            nextMatchId: nextMatch?.bmatch_id ?? null,
-            tournamentSubAId: m.bmatch_submission_a ?? "",
-            tournamentSubBId: m.bmatch_submission_b ?? "",
-          };
-        });
-
-        setMatches(built);
-      } catch (err) {
-        console.error(err);
-        setError("Failed to load bracket.");
-      } finally {
-        setLoading(false);
+        await supabase.rpc("advance_tournament_lifecycle", { p_tournament_id: Number(tournamentId) });
+      } catch (e) {
+        console.warn("Lifecycle update check failed:", e);
       }
-    }
 
-    load();
+      const { data: tournamentRow, error: tournamentError } = await supabase
+        .from("tournament")
+        .select("tournament_id, tournament_title, tournament_status, tournament_start_date, tournament_s2_start_date, tournament_end_date")
+        .eq("tournament_id", Number(tournamentId))
+        .single();
+
+      if (tournamentError) {
+        setError("Unable to load tournament details.");
+        return;
+      }
+
+      setTournament(tournamentRow);
+
+      const { data: bracketRows, error: bracketError } = await supabase
+        .from("bracket")
+        .select("bracket_id, bracket_round_number, bracket_status")
+        .eq("tournament_id", Number(tournamentId));
+
+      if (bracketError) {
+        setError("Unable to load bracket for this tournament.");
+        return;
+      }
+
+      // No bracket yet is a valid state (e.g. stage1 waiting for stage2). Treat as empty matches.
+      if (!bracketRows || !bracketRows.length) {
+        setMatches([]);
+        setTotalRounds(1);
+        setActiveRound(1);
+        return;
+      }
+
+      const bracketIds = bracketRows.map((row) => row.bracket_id);
+      const computedTotalRounds = Math.max(1, ...bracketRows.map((row) => row.bracket_round_number ?? 1));
+      const computedActiveRound = bracketRows.find((row) => row.bracket_status === "active")?.bracket_round_number
+        ?? computedTotalRounds;
+
+      setTotalRounds(computedTotalRounds);
+      setActiveRound(computedActiveRound);
+
+      const { data: rawMatches, error: matchError } = await supabase
+        .from("bracket_match")
+        .select("*")
+        .in("bracket_id", bracketIds);
+
+      if (matchError) {
+        setError("No matches found for this bracket.");
+        return;
+      }
+
+      // If bracket exists but no matches have been created yet, treat as empty.
+      if (!rawMatches || !rawMatches.length) {
+        setMatches([]);
+        setTotalRounds(1);
+        setActiveRound(1);
+        return;
+      }
+
+      const subIds = [
+        ...new Set(
+          [
+            ...rawMatches.map((m) => m.bmatch_submission_a),
+            ...rawMatches.map((m) => m.bmatch_submission_b),
+          ].filter(Boolean)
+        ),
+      ];
+
+      const { data: subs } = await supabase
+        .from("tournament_submission")
+        .select("tournamentsub_id, concept(concept_title, concept_description, concept_styling)")
+        .in("tournamentsub_id", subIds);
+
+      const nameMap: Record<string, string> = {};
+      const coverMap: Record<string, string | null> = {};
+      const descMap: Record<string, string | null> = {};
+
+      (subs ?? []).forEach((s: any) => {
+        const c = s.concept;
+        if (!c) return;
+        nameMap[s.tournamentsub_id] = c.concept_title ?? "TBD";
+        descMap[s.tournamentsub_id] = c.concept_description ?? null;
+        coverMap[s.tournamentsub_id] = c.concept_styling?.book_cover ?? null;
+      });
+
+      const sorted = [...rawMatches].sort((a, b) => {
+        const ar = a.bmatch_index?.round ?? 1;
+        const br = b.bmatch_index?.round ?? 1;
+        const as = a.bmatch_index?.slot ?? 1;
+        const bs = b.bmatch_index?.slot ?? 1;
+        return ar !== br ? ar - br : as - bs;
+      });
+
+      const r1Count = sorted.filter((m) => (m.bmatch_index?.round ?? 1) === 1).length;
+      const computedSvgRounds = Math.max(1, Math.ceil(Math.log2(r1Count * 2)));
+      setTotalRounds(computedSvgRounds);
+
+      const byRound: Record<number, typeof sorted> = {};
+      sorted.forEach((m) => {
+        const r = m.bmatch_index?.round ?? 1;
+        if (!byRound[r]) byRound[r] = [];
+        byRound[r].push(m);
+      });
+
+      const r1Matches = byRound[1] ?? [];
+      const r1Half = Math.ceil(r1Matches.length / 2);
+      const finalRound = computedSvgRounds;
+
+      const built: BracketMatch[] = sorted.map((m) => {
+        const round = m.bmatch_index?.round ?? 1;
+        const roundMatches = byRound[round] ?? [];
+        const indexInRound = roundMatches.findIndex((x) => x.bmatch_id === m.bmatch_id);
+
+        let side: "left" | "right" | "final" = "left";
+        if (round === finalRound) {
+          side = "final";
+        } else if (round === 1) {
+          side = indexInRound < r1Half ? "left" : "right";
+        } else {
+          side = indexInRound < roundMatches.length / 2 ? "left" : "right";
+        }
+
+        const nextRound = round + 1;
+        const nextRoundMatches = byRound[nextRound] ?? null;
+        const nextMatch = nextRoundMatches?.[Math.floor(indexInRound / 2)] ?? null;
+
+        return {
+          id: m.bmatch_id,
+          bmatchId: String(m.bmatch_id),
+          roundNumber: round,
+          slot: m.bmatch_index?.slot ?? 1,
+          nameA: nameMap[m.bmatch_submission_a] ?? "TBD",
+          nameB: nameMap[m.bmatch_submission_b] ?? "TBD",
+          coverA: coverMap[m.bmatch_submission_a] ?? null,
+          coverB: coverMap[m.bmatch_submission_b] ?? null,
+          descA: descMap[m.bmatch_submission_a] ?? null,
+          descB: descMap[m.bmatch_submission_b] ?? null,
+          status: m.bmatch_status ?? "active",
+          side,
+          indexInRound,
+          nextMatchId: nextMatch?.bmatch_id ?? null,
+          tournamentSubAId: m.bmatch_submission_a ?? "",
+          tournamentSubBId: m.bmatch_submission_b ?? "",
+        };
+      });
+
+      setMatches(built);
+    } catch (err) {
+      console.error(err);
+      setError("Failed to load bracket.");
+    } finally {
+      if (!silent) setLoading(false);
+    }
   }, [tournamentId]);
+
+  useEffect(() => {
+    load();
+    // hydrate admin flag from user profile
+    (async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) return;
+        const { data: profile, error } = await supabase
+          .from("user")
+          .select("user_role")
+          .eq("user_id", user.id)
+          .single();
+        if (!error && profile && profile.user_role === "admin") setIsAdmin(true);
+      } catch (e) {
+        console.warn("admin check failed", e);
+      }
+    })();
+  }, [load]);
+
+  useEffect(() => {
+    const timerId = window.setInterval(() => setNow(Date.now()), 15000);
+    return () => window.clearInterval(timerId);
+  }, []);
+
+  useEffect(() => {
+    const timerId = window.setInterval(() => {
+      load(true);
+    }, 30000);
+
+    return () => window.clearInterval(timerId);
+  }, [load]);
+
+  const resolvedStatus = tournament ? resolveTournamentLifecycleStatus(tournament, now) : "upcoming";
+  const totalCountdown = getCountdownParts(tournament?.tournament_end_date ? new Date(tournament.tournament_end_date).getTime() : null, now);
+  const milestone = getTournamentMilestoneTarget(tournament, resolvedStatus as TournamentLifecycleStatus);
+  const milestoneCountdown = getCountdownParts(milestone.targetMs, now);
+  const roundCountdownTarget = getRoundCountdownTarget(tournament, totalRounds, activeRound);
+  const roundCountdown = getCountdownParts(roundCountdownTarget, now);
 
   const handleMatchClick = (m: BracketMatch) => {
     router.push(`/tournament/${tournamentId}/tournamentbracket/${m.bmatchId}/onevsone`);
   };
 
+  const openConfirm = (action: "stage2" | "round") => {
+    setConfirmAction(action);
+    setConfirmOpen(true);
+  };
+
+  const doAdvance = async () => {
+    if (!tournament) return;
+    setConfirmOpen(false);
+    setLoading(true);
+    try {
+      if (confirmAction === "stage2") {
+        // set stage2 start to now and seed
+        const { error: upErr } = await supabase
+          .from("tournament")
+          .update({ tournament_s2_start_date: new Date().toISOString() })
+          .eq("tournament_id", tournament.tournament_id);
+        if (upErr) throw upErr;
+
+        const { error: rpcErr } = await supabase.rpc("seed_tournament_brackets", { p_tournament_id: Number(tournament.tournament_id) });
+        if (rpcErr) throw rpcErr;
+      } else if (confirmAction === "round") {
+        // finalize the active round
+        const { error: rpcErr } = await supabase.rpc("finalize_bracket_round", {
+          p_tournament_id: Number(tournament.tournament_id),
+          p_round: Number(activeRound),
+          p_force: true,
+        });
+        if (rpcErr) throw rpcErr;
+      }
+
+      // reschedule jobs and refresh state
+      await supabase.rpc("reschedule_tournament_jobs", { p_tournament_id: Number(tournament.tournament_id) });
+      await load(true);
+    } catch (err: any) {
+      console.error("Advance action failed", err);
+      setError(err?.message ?? String(err));
+    } finally {
+      setLoading(false);
+      setConfirmAction(null);
+    }
+  };
+
   if (loading) return <div className="p-6 text-gray-500">Loading bracket...</div>;
   if (error) return <div className="p-6 text-red-500 relative">
     {error}
-    <Button className="absolute left-0 top-20 bg-white hover:bg-slate-100 tracking-normal text-sm font-medium text-slate-700" onClick={() => { router.push("./") }}>
-      ← Back to Tournament
-    </Button>
-  </div>;
-  if (!matches.length) return <div className="p-6 text-gray-400 relative">
-    No matches available.
     <Button className="absolute left-0 top-20 bg-white hover:bg-slate-100 tracking-normal text-sm font-medium text-slate-700" onClick={() => { router.push("./") }}>
       ← Back to Tournament
     </Button>
@@ -740,11 +866,65 @@ export default function TournamentBracketPage({
           ← Back to Tournament
         </Button>
       </h1>
+
+      {tournament && (
+        <div className="mb-6 grid gap-4 rounded-2xl border border-emerald-200 bg-gradient-to-r from-white to-emerald-50 p-5 shadow-sm lg:grid-cols-3">
+          <div>
+            <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Live tournament status</p>
+            <p className="mt-2 text-2xl font-black tracking-[-0.04em] text-[#1d2436]">
+              {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)}
+            </p>
+            <p className="mt-1 text-sm text-[#6b7490]">Auto-refreshes every 30s</p>
+          </div>
+
+          <div className="rounded-2xl bg-white px-4 py-4 shadow-sm">
+            <p className="text-xs font-black uppercase tracking-[0.16em] text-purple-700">Tournament ends in</p>
+            <p className="mt-2 text-xl font-extrabold text-purple-900">{formatCountdownParts(totalCountdown)}</p>
+          </div>
+
+          <div className="rounded-2xl bg-white px-4 py-4 shadow-sm">
+            <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">{milestone.label}</p>
+            <p className="mt-2 text-xl font-extrabold text-emerald-900">{formatCountdownParts(milestoneCountdown)}</p>
+            {resolvedStatus === "stage2" && (
+              <p className="mt-2 text-sm text-[#6b7490]">Current round remaining: {formatCountdownParts(roundCountdown)}</p>
+            )}
+            {isAdmin && (tournament.tournament_status === "stage1" || tournament.tournament_status === "stage2") && (
+              <div className="mt-3 flex gap-2">
+                {tournament.tournament_status === "stage1" && (
+                  <Button variant="outline" onClick={() => openConfirm("stage2")}>Advance to Stage 2 (seed now)</Button>
+                )}
+                {tournament.tournament_status === "stage2" && (
+                  <Button variant="outline" onClick={() => openConfirm("round")}>Advance to Round {activeRound + 1}</Button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
       <BracketSVG
         matches={matches}
         totalRounds={totalRounds}
         onMatchClick={handleMatchClick}
       />
+      {/* Confirmation modal for admin advance actions */}
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm advance</DialogTitle>
+            <DialogDescription>
+              {confirmAction === "stage2" && "This will set the Stage 2 start time to now, seed the bracket, and start round 1. Continue?"}
+              {confirmAction === "round" && `This will finalize round ${activeRound} immediately and advance winners to round ${activeRound + 1}. Continue?`}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <div className="flex gap-2">
+              <Button variant="secondary" onClick={() => setConfirmOpen(false)}>Cancel</Button>
+              <Button onClick={doAdvance} disabled={loading}>Confirm</Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dialog";
 import {
   formatCountdownParts,
+  formatStatusLabel,
   getCountdownParts,
   getRoundCountdownTarget,
   getTournamentMilestoneTarget,
@@ -799,7 +800,7 @@ export default function TournamentBracketPage({
 
   const resolvedStatus = tournament ? resolveTournamentLifecycleStatus(tournament, now) : "upcoming";
   const totalCountdown = getCountdownParts(tournament?.tournament_end_date ? new Date(tournament.tournament_end_date).getTime() : null, now);
-  const milestone = getTournamentMilestoneTarget(tournament, resolvedStatus as TournamentLifecycleStatus);
+  const milestone = getTournamentMilestoneTarget(tournament, resolvedStatus as TournamentLifecycleStatus, activeRound, totalRounds);
   const milestoneCountdown = getCountdownParts(milestone.targetMs, now);
   const roundCountdownTarget = getRoundCountdownTarget(tournament, totalRounds, activeRound);
   const roundCountdown = getCountdownParts(roundCountdownTarget, now);
@@ -873,7 +874,7 @@ export default function TournamentBracketPage({
             <div>
               <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Tournament status</p>
               <p className="mt-2 text-2xl font-black tracking-[-0.04em] text-[#1d2436]">
-                {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)}
+                {formatStatusLabel(resolvedStatus, activeRound)}
               </p>
             </div>
             <span className="rounded-full bg-emerald-100 px-4 py-2 text-xs font-bold uppercase tracking-[0.12em] text-emerald-700">
@@ -885,7 +886,7 @@ export default function TournamentBracketPage({
             <div>
               <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">Live tournament status</p>
               <p className="mt-2 text-2xl font-black tracking-[-0.04em] text-[#1d2436]">
-                {resolvedStatus.charAt(0).toUpperCase() + resolvedStatus.slice(1)}
+                {formatStatusLabel(resolvedStatus, activeRound)}
               </p>
               <p className="mt-1 text-sm text-[#6b7490]">Auto-refreshes every 30s</p>
             </div>
@@ -898,9 +899,6 @@ export default function TournamentBracketPage({
             <div className="rounded-2xl bg-white px-4 py-4 shadow-sm">
               <p className="text-xs font-black uppercase tracking-[0.16em] text-emerald-700">{milestone.label}</p>
               <p className="mt-2 text-xl font-extrabold text-emerald-900">{formatCountdownParts(milestoneCountdown)}</p>
-              {resolvedStatus === "stage2" && (
-                <p className="mt-2 text-sm text-[#6b7490]">Current round remaining: {formatCountdownParts(roundCountdown)}</p>
-              )}
               {isAdmin && (tournament.tournament_status === "stage1" || tournament.tournament_status === "stage2") && (
                 <div className="mt-3 flex gap-2">
                   {tournament.tournament_status === "stage1" && (

--- a/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
@@ -241,6 +241,7 @@ function BracketSVG({
   resolvedStatus,
   activeRound,
   userVotes,
+  bracketWinnerId,
 }: {
   matches: BracketMatch[];
   totalRounds: number;
@@ -248,6 +249,7 @@ function BracketSVG({
   resolvedStatus: TournamentLifecycleStatus;
   activeRound: number | null;
   userVotes: Record<number, string>;
+  bracketWinnerId?: string | null;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [hoveredMatch, setHoveredMatch] = useState<BracketMatch | null>(null);
@@ -586,6 +588,28 @@ function BracketSVG({
     const hasVoted = !!userVotes[m.id];
     const dotColor = hasVoted ? "#3b82f6" : "#ef4444";
 
+    let winnerSide: "a" | "b" | null = null;
+    if (isCompleted) {
+      if (m.side === "final") {
+        if (bracketWinnerId === m.tournamentSubAId) winnerSide = "a";
+        else if (bracketWinnerId === m.tournamentSubBId) winnerSide = "b";
+      } else if (m.nextMatchId) {
+        const nextMatch = matches.find((x) => x.id === m.nextMatchId);
+        if (nextMatch) {
+          if (nextMatch.tournamentSubAId === m.tournamentSubAId || nextMatch.tournamentSubBId === m.tournamentSubAId) {
+            winnerSide = "a";
+          } else if (nextMatch.tournamentSubAId === m.tournamentSubBId || nextMatch.tournamentSubBId === m.tournamentSubBId) {
+            winnerSide = "b";
+          }
+        }
+      }
+    }
+
+    const isWinnerA = winnerSide === "a";
+    const isLoserA = winnerSide === "b";
+    const isWinnerB = winnerSide === "b";
+    const isLoserB = winnerSide === "a";
+
     cards.push(
       <g key={m.id} onClick={() => onMatchClick(m)} style={{ cursor: "pointer" }}>
         <rect x={p.x + 2} y={p.y + 2} width={MW} height={MH} rx={6} fill="#00000015" />
@@ -594,10 +618,16 @@ function BracketSVG({
           stroke={isHovered ? "#7c3aed" : "#e5e7eb"}
           strokeWidth={isHovered ? 2 : 1} />
         <line x1={p.x + 1} y1={p.y + MH / 2} x2={p.x + MW - 1} y2={p.y + MH / 2} stroke="#f3f4f6" strokeWidth={1} />
-        <text x={p.x + 10} y={p.y + MH / 4 + 4} fontSize={11} fill="#1a1a1a" fontFamily="sans-serif">
+        <text x={p.x + 10} y={p.y + MH / 4 + 4} fontSize={11}
+          fill="#1a1a1a"
+          fontWeight={isWinnerA ? "bold" : "normal"}
+          fontFamily="sans-serif">
           {trunc(m.nameA, 22)}
         </text>
-        <text x={p.x + 10} y={p.y + (MH * 3) / 4 + 4} fontSize={11} fill="#1a1a1a" fontFamily="sans-serif">
+        <text x={p.x + 10} y={p.y + (MH * 3) / 4 + 4} fontSize={11}
+          fill="#1a1a1a"
+          fontWeight={isWinnerB ? "bold" : "normal"}
+          fontFamily="sans-serif">
           {trunc(m.nameB, 22)}
         </text>
         <circle cx={p.x + MW - 10} cy={p.y + MH / 2} r={4} fill={dotColor} />
@@ -666,6 +696,7 @@ export default function TournamentBracketPage({
   const [totalRounds, setTotalRounds] = useState(1);
   const [activeRound, setActiveRound] = useState(1);
   const [userVotes, setUserVotes] = useState<Record<number, string>>({});
+  const [bracketWinnerId, setBracketWinnerId] = useState<string | null>(null);
   const [tournament, setTournament] = useState<{
     tournament_id: number;
     tournament_title: string;
@@ -708,7 +739,7 @@ export default function TournamentBracketPage({
 
       const { data: bracketRows, error: bracketError } = await supabase
         .from("bracket")
-        .select("bracket_id, bracket_round_number, bracket_status")
+        .select("bracket_id, bracket_round_number, bracket_status, tournamentsub_id")
         .eq("tournament_id", Number(tournamentId));
 
       if (bracketError) {
@@ -721,6 +752,7 @@ export default function TournamentBracketPage({
         setMatches([]);
         setTotalRounds(1);
         setActiveRound(1);
+        setBracketWinnerId(null);
         return;
       }
 
@@ -728,9 +760,11 @@ export default function TournamentBracketPage({
       const computedTotalRounds = Math.max(1, ...bracketRows.map((row) => row.bracket_round_number ?? 1));
       const computedActiveRound = bracketRows.find((row) => row.bracket_status === "active")?.bracket_round_number
         ?? computedTotalRounds;
+      const winnerId = bracketRows.find((row) => row.tournamentsub_id)?.tournamentsub_id ?? null;
 
       setTotalRounds(computedTotalRounds);
       setActiveRound(computedActiveRound);
+      setBracketWinnerId(winnerId);
 
       const { data: rawMatches, error: matchError } = await supabase
         .from("bracket_match")
@@ -1019,6 +1053,7 @@ export default function TournamentBracketPage({
         resolvedStatus={resolvedStatus}
         activeRound={activeRound}
         userVotes={userVotes}
+        bracketWinnerId={bracketWinnerId}
       />
       {/* Confirmation modal for admin advance actions */}
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>

--- a/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
@@ -51,6 +51,8 @@ interface BracketMatch {
   coverB: string | null;
   descA: string | null;
   descB: string | null;
+  deletedA: boolean;
+  deletedB: boolean;
   status: string;
   side: "left" | "right" | "final";
   indexInRound: number;
@@ -134,12 +136,21 @@ function MatchTooltip({
         <div style={{ display: "flex", gap: 10, alignItems: "flex-start" }}>
           {/* Book A */}
           <div style={{ flex: 1, display: "flex", gap: 8 }}>
-            <img
-              src={getCoverUrl(match.coverA)}
-              alt={match.nameA}
-              onError={(e) => { (e.target as HTMLImageElement).src = "/covers/space.jpg"; }}
-              style={{ width: 52, height: 70, objectFit: "cover", borderRadius: 6, boxShadow: "0 2px 8px rgba(0,0,0,0.15)", flexShrink: 0 }}
-            />
+            {match.deletedA ? (
+              <div style={{
+                width: 52, height: 70, borderRadius: 6, flexShrink: 0,
+                background: "#f3f4f6", border: "2px dashed #d1d5db",
+                display: "flex", alignItems: "center", justifyContent: "center",
+                fontSize: 20,
+              }}>📕</div>
+            ) : (
+              <img
+                src={getCoverUrl(match.coverA)}
+                alt={match.nameA}
+                onError={(e) => { (e.target as HTMLImageElement).src = "/covers/space.jpg"; }}
+                style={{ width: 52, height: 70, objectFit: "cover", borderRadius: 6, boxShadow: "0 2px 8px rgba(0,0,0,0.15)", flexShrink: 0 }}
+              />
+            )}
             <div style={{ minWidth: 0 }}>
               <div style={{ fontSize: 12, fontWeight: 700, color: "#111827", lineHeight: 1.3, marginBottom: 4 }}>
                 {match.nameA || "TBD"}
@@ -176,12 +187,21 @@ function MatchTooltip({
 
           {/* Book B */}
           <div style={{ flex: 1, display: "flex", gap: 8, flexDirection: "row-reverse" }}>
-            <img
-              src={getCoverUrl(match.coverB)}
-              alt={match.nameB}
-              onError={(e) => { (e.target as HTMLImageElement).src = "/covers/space.jpg"; }}
-              style={{ width: 52, height: 70, objectFit: "cover", borderRadius: 6, boxShadow: "0 2px 8px rgba(0,0,0,0.15)", flexShrink: 0 }}
-            />
+            {match.deletedB ? (
+              <div style={{
+                width: 52, height: 70, borderRadius: 6, flexShrink: 0,
+                background: "#f3f4f6", border: "2px dashed #d1d5db",
+                display: "flex", alignItems: "center", justifyContent: "center",
+                fontSize: 20,
+              }}>📕</div>
+            ) : (
+              <img
+                src={getCoverUrl(match.coverB)}
+                alt={match.nameB}
+                onError={(e) => { (e.target as HTMLImageElement).src = "/covers/space.jpg"; }}
+                style={{ width: 52, height: 70, objectFit: "cover", borderRadius: 6, boxShadow: "0 2px 8px rgba(0,0,0,0.15)", flexShrink: 0 }}
+              />
+            )}
             <div style={{ minWidth: 0, textAlign: "right" }}>
               <div style={{ fontSize: 12, fontWeight: 700, color: "#111827", lineHeight: 1.3, marginBottom: 4 }}>
                 {match.nameB || "TBD"}
@@ -619,16 +639,18 @@ function BracketSVG({
           strokeWidth={isHovered ? 2 : 1} />
         <line x1={p.x + 1} y1={p.y + MH / 2} x2={p.x + MW - 1} y2={p.y + MH / 2} stroke="#f3f4f6" strokeWidth={1} />
         <text x={p.x + 10} y={p.y + MH / 4 + 4} fontSize={11}
-          fill="#1a1a1a"
+          fill={m.deletedA ? "#9ca3af" : "#1a1a1a"}
           fontWeight={isWinnerA ? "bold" : "normal"}
+          fontStyle={m.deletedA ? "italic" : "normal"}
           fontFamily="sans-serif">
-          {trunc(m.nameA, 22)}
+          {m.deletedA ? "Unavailable" : trunc(m.nameA, 22)}
         </text>
         <text x={p.x + 10} y={p.y + (MH * 3) / 4 + 4} fontSize={11}
-          fill="#1a1a1a"
+          fill={m.deletedB ? "#9ca3af" : "#1a1a1a"}
           fontWeight={isWinnerB ? "bold" : "normal"}
+          fontStyle={m.deletedB ? "italic" : "normal"}
           fontFamily="sans-serif">
-          {trunc(m.nameB, 22)}
+          {m.deletedB ? "Unavailable" : trunc(m.nameB, 22)}
         </text>
         <circle cx={p.x + MW - 10} cy={p.y + MH / 2} r={4} fill={dotColor} />
       </g>
@@ -795,16 +817,23 @@ export default function TournamentBracketPage({
 
       const { data: subs } = await supabase
         .from("tournament_submission")
-        .select("tournamentsub_id, concept(concept_title, concept_description, concept_styling)")
+        .select("tournamentsub_id, tournamentsub_status, concept(concept_title, concept_description, concept_styling, concept_status)")
         .in("tournamentsub_id", subIds);
 
       const nameMap: Record<string, string> = {};
       const coverMap: Record<string, string | null> = {};
       const descMap: Record<string, string | null> = {};
+      const deletedSet = new Set<string>();
 
       (subs ?? []).forEach((s: any) => {
+        const isSubDeleted = s.tournamentsub_status === 'deleted' || s.tournamentsub_status === 'terminated';
         const c = s.concept;
-        if (!c) return;
+        const isConceptDeleted = !c || c.concept_status === 'deleted';
+
+        if (isSubDeleted || isConceptDeleted) {
+          deletedSet.add(s.tournamentsub_id);
+          return;
+        }
         nameMap[s.tournamentsub_id] = c.concept_title ?? "TBD";
         descMap[s.tournamentsub_id] = c.concept_description ?? null;
         coverMap[s.tournamentsub_id] = c.concept_styling?.book_cover ?? null;
@@ -862,6 +891,8 @@ export default function TournamentBracketPage({
           coverB: coverMap[m.bmatch_submission_b] ?? null,
           descA: descMap[m.bmatch_submission_a] ?? null,
           descB: descMap[m.bmatch_submission_b] ?? null,
+          deletedA: deletedSet.has(m.bmatch_submission_a),
+          deletedB: deletedSet.has(m.bmatch_submission_b),
           status: m.bmatch_status ?? "active",
           side,
           indexInRound,

--- a/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
+++ b/app/(routes)/tournament/[id]/tournamentbracket/_components/TournamentBracketPage.tsx
@@ -81,11 +81,13 @@ function MatchTooltip({
   mouseX,
   mouseY,
   containerW,
+  userVotes,
 }: {
   match: BracketMatch;
   mouseX: number;
   mouseY: number;
   containerW: number;
+  userVotes: Set<string>;
 }) {
   const TOOLTIP_W = 360;
   const OFFSET = 16;
@@ -96,6 +98,10 @@ function MatchTooltip({
     : mouseX + OFFSET;
 
   const top = mouseY - 90;
+
+  const votedA = userVotes.has(match.tournamentSubAId);
+  const votedB = userVotes.has(match.tournamentSubBId);
+  const hasVoted = votedA || votedB;
 
   return (
     <div
@@ -146,6 +152,15 @@ function MatchTooltip({
                   {match.descA}
                 </div>
               )}
+              {votedA && (
+                <div style={{
+                  display: "inline-block", fontSize: 9, fontWeight: 700,
+                  padding: "2px 8px", borderRadius: 4, background: "#dbeafe",
+                  color: "#1e40af", marginTop: 6
+                }}>
+                  ✓ Voted
+                </div>
+              )}
             </div>
           </div>
 
@@ -179,12 +194,29 @@ function MatchTooltip({
                   {match.descB}
                 </div>
               )}
+              {votedB && (
+                <div style={{
+                  display: "inline-block", fontSize: 9, fontWeight: 700,
+                  padding: "2px 8px", borderRadius: 4, background: "#dbeafe",
+                  color: "#1e40af", marginTop: 6
+                }}>
+                  ✓ Voted
+                </div>
+              )}
             </div>
           </div>
         </div>
 
         {/* Status */}
-        <div style={{ display: "flex", justifyContent: "center" }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 6, alignItems: "center" }}>
+          {!hasVoted && (
+            <span style={{
+              fontSize: 9, fontWeight: 700, padding: "2px 10px", borderRadius: 20,
+              background: "#fee2e2", color: "#991b1b", letterSpacing: 0.5, textTransform: "uppercase"
+            }}>
+              ● Not Voted
+            </span>
+          )}
           <span style={{
             fontSize: 10, fontWeight: 600, padding: "2px 12px", borderRadius: 20,
             background: match.status === "completed" ? "#dcfce7" : "#fef9c3",
@@ -205,10 +237,16 @@ function BracketSVG({
   matches,
   totalRounds,
   onMatchClick,
+  resolvedStatus,
+  activeRound,
+  userVotes,
 }: {
   matches: BracketMatch[];
   totalRounds: number;
   onMatchClick: (m: BracketMatch) => void;
+  resolvedStatus: TournamentLifecycleStatus;
+  activeRound: number | null;
+  userVotes: Set<string>;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [hoveredMatch, setHoveredMatch] = useState<BracketMatch | null>(null);
@@ -454,10 +492,44 @@ function BracketSVG({
   // ROUND LABELS
   // ----------------------------
   const labels: JSX.Element[] = [];
-  const roundNames = ["Round of 32", "Round of 16", "Quarterfinals", "Semifinals"];
+
+  const roundStatusColors = {
+    finished: {
+      fill: "#dcfce7",
+      stroke: "#10b981",
+      text: "#065f46"
+    },
+    active: {
+      fill: "#fef9c3",
+      stroke: "#eab308",
+      text: "#713f12"
+    },
+    upcoming: {
+      fill: "#f3f4f6",
+      stroke: "#d1d5db",
+      text: "#6b7280"
+    }
+  };
+
+  const getRoundState = (rNum: number) => {
+    if (resolvedStatus === "concluded" || resolvedStatus === "terminated") {
+      return "finished";
+    }
+    if (resolvedStatus === "stage2") {
+      if (!activeRound) return "upcoming";
+      if (rNum < activeRound) return "finished";
+      if (rNum === activeRound) return "active";
+      return "upcoming";
+    }
+    return "upcoming";
+  };
 
   for (let rIdx = 0; rIdx < sideRounds; rIdx++) {
-    const label = roundNames[roundNames.length - sideRounds + rIdx] ?? `Round of ${2 ** (sideRounds - rIdx + 1)}`;
+    const roundNumber = rIdx + 1;
+    const state = getRoundState(roundNumber);
+    const colors = roundStatusColors[state];
+
+    const label = `Round ${roundNumber}`;
     const lX = rIdx * (MW + RG) + MW / 2;
     const rX = totalW - rIdx * (MW + RG) - MW / 2;
     const badgeWidth = MW * 0.78;
@@ -467,8 +539,8 @@ function BracketSVG({
     labels.push(
       <g key={`ll-${rIdx}`}>
         <rect x={lX - badgeWidth / 2} y={badgeY} width={badgeWidth} height={badgeHeight} rx={badgeHeight / 2}
-          fill={LABEL_FILL} stroke={LABEL_STROKE} strokeWidth={1} />
-        <text x={lX} y={badgeY + badgeHeight / 2 + 4} textAnchor="middle" fontSize={12} fill={LABEL_TEXT} fontWeight={700}>
+          fill={colors.fill} stroke={colors.stroke} strokeWidth={1} />
+        <text x={lX} y={badgeY + badgeHeight / 2 + 4} textAnchor="middle" fontSize={12} fill={colors.text} fontWeight={700}>
           {label}
         </text>
       </g>
@@ -476,20 +548,24 @@ function BracketSVG({
     labels.push(
       <g key={`rl-${rIdx}`}>
         <rect x={rX - badgeWidth / 2} y={badgeY} width={badgeWidth} height={badgeHeight} rx={badgeHeight / 2}
-          fill={LABEL_FILL} stroke={LABEL_STROKE} strokeWidth={1} />
-        <text x={rX} y={badgeY + badgeHeight / 2 + 4} textAnchor="middle" fontSize={12} fill={LABEL_TEXT} fontWeight={700}>
+          fill={colors.fill} stroke={colors.stroke} strokeWidth={1} />
+        <text x={rX} y={badgeY + badgeHeight / 2 + 4} textAnchor="middle" fontSize={12} fill={colors.text} fontWeight={700}>
           {label}
         </text>
       </g>
     );
   }
 
+  const finalRoundNumber = sideRounds + 1;
+  const finalState = getRoundState(finalRoundNumber);
+  const finalColors = roundStatusColors[finalState];
+
   labels.push(
     <g key="final-label">
       <rect x={finalX + MW / 2 - 75} y={8} width={150} height={30} rx={15}
-        fill={LABEL_FILL} stroke={LABEL_STROKE} strokeWidth={1} />
-      <text x={finalX + MW / 2} y={8 + 30 / 2 + 4} textAnchor="middle" fontSize={13} fill={LABEL_TEXT} fontWeight={700}>
-        Final
+        fill={finalColors.fill} stroke={finalColors.stroke} strokeWidth={1} />
+      <text x={finalX + MW / 2} y={8 + 30 / 2 + 4} textAnchor="middle" fontSize={13} fill={finalColors.text} fontWeight={700}>
+        Round {finalRoundNumber}
       </text>
     </g>
   );
@@ -506,6 +582,9 @@ function BracketSVG({
     const isCompleted = m.status === "completed";
     const isHovered = hoveredMatch?.id === m.id;
 
+    const hasVoted = userVotes.has(m.tournamentSubAId) || userVotes.has(m.tournamentSubBId);
+    const dotColor = hasVoted ? "#3b82f6" : "#ef4444";
+
     cards.push(
       <g key={m.id} onClick={() => onMatchClick(m)} style={{ cursor: "pointer" }}>
         <rect x={p.x + 2} y={p.y + 2} width={MW} height={MH} rx={6} fill="#00000015" />
@@ -520,9 +599,7 @@ function BracketSVG({
         <text x={p.x + 10} y={p.y + (MH * 3) / 4 + 4} fontSize={11} fill="#1a1a1a" fontFamily="sans-serif">
           {trunc(m.nameB, 22)}
         </text>
-        {isCompleted && (
-          <circle cx={p.x + MW - 10} cy={p.y + MH / 2} r={4} fill="#22c55e" />
-        )}
+        <circle cx={p.x + MW - 10} cy={p.y + MH / 2} r={4} fill={dotColor} />
       </g>
     );
   });
@@ -568,6 +645,7 @@ function BracketSVG({
             mouseX={mousePos.x}
             mouseY={mousePos.y}
             containerW={containerW}
+            userVotes={userVotes}
           />
         )}
       </div>
@@ -586,6 +664,7 @@ export default function TournamentBracketPage({
   const [matches, setMatches] = useState<BracketMatch[]>([]);
   const [totalRounds, setTotalRounds] = useState(1);
   const [activeRound, setActiveRound] = useState(1);
+  const [userVotes, setUserVotes] = useState<Set<string>>(new Set());
   const [tournament, setTournament] = useState<{
     tournament_id: number;
     tournament_title: string;
@@ -758,6 +837,18 @@ export default function TournamentBracketPage({
       });
 
       setMatches(built);
+
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        const { data: voteRows } = await supabase
+          .from("vote")
+          .select("tournamentsub_id")
+          .eq("user_id", user.id);
+        
+        if (voteRows) {
+          setUserVotes(new Set(voteRows.map((v) => v.tournamentsub_id)));
+        }
+      }
     } catch (err) {
       console.error(err);
       setError("Failed to load bracket.");
@@ -918,6 +1009,9 @@ export default function TournamentBracketPage({
         matches={matches}
         totalRounds={totalRounds}
         onMatchClick={handleMatchClick}
+        resolvedStatus={resolvedStatus}
+        activeRound={activeRound}
+        userVotes={userVotes}
       />
       {/* Confirmation modal for admin advance actions */}
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>

--- a/app/_utilities/tournamentLifecycle.ts
+++ b/app/_utilities/tournamentLifecycle.ts
@@ -38,23 +38,7 @@ export function resolveTournamentLifecycleStatus(
 ): TournamentLifecycleStatus {
   if (!tournament) return "upcoming";
 
-  const storedStatus = tournament
-    .tournament_status as TournamentLifecycleStatus;
-  if (
-    storedStatus === "terminated" || storedStatus === "concluded" ||
-    storedStatus === "stage2"
-  ) {
-    return storedStatus;
-  }
-
-  const startMs = toMs(tournament.tournament_start_date);
-  const stage2Ms = toMs(tournament.tournament_s2_start_date);
-  const endMs = toMs(tournament.tournament_end_date);
-
-  if (endMs !== null && now >= endMs) return "concluded";
-  if (stage2Ms !== null && now >= stage2Ms) return "stage2";
-  if (startMs !== null && now >= startMs) return "stage1";
-  return "upcoming";
+  return tournament.tournament_status as TournamentLifecycleStatus;
 }
 
 export function getCountdownParts(

--- a/app/_utilities/tournamentLifecycle.ts
+++ b/app/_utilities/tournamentLifecycle.ts
@@ -1,0 +1,139 @@
+export type TournamentLifecycleStatus =
+  | "upcoming"
+  | "stage1"
+  | "stage2"
+  | "concluded"
+  | "terminated";
+
+export type TournamentTiming = {
+  tournament_status: string;
+  tournament_start_date: string;
+  tournament_s2_start_date: string | null;
+  tournament_end_date: string;
+};
+
+export type CountdownParts = {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  totalMs: number;
+};
+
+type CountdownTarget = {
+  label: string;
+  targetMs: number | null;
+};
+
+function toMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function resolveTournamentLifecycleStatus(
+  tournament: TournamentTiming | null | undefined,
+  now = Date.now(),
+): TournamentLifecycleStatus {
+  if (!tournament) return "upcoming";
+
+  const storedStatus = tournament
+    .tournament_status as TournamentLifecycleStatus;
+  if (
+    storedStatus === "terminated" || storedStatus === "concluded" ||
+    storedStatus === "stage2"
+  ) {
+    return storedStatus;
+  }
+
+  const startMs = toMs(tournament.tournament_start_date);
+  const stage2Ms = toMs(tournament.tournament_s2_start_date);
+  const endMs = toMs(tournament.tournament_end_date);
+
+  if (endMs !== null && now >= endMs) return "concluded";
+  if (stage2Ms !== null && now >= stage2Ms) return "stage2";
+  if (startMs !== null && now >= startMs) return "stage1";
+  return "upcoming";
+}
+
+export function getCountdownParts(
+  targetMs: number | null | undefined,
+  now = Date.now(),
+): CountdownParts {
+  if (!targetMs) {
+    return { days: 0, hours: 0, minutes: 0, seconds: 0, totalMs: 0 };
+  }
+
+  const totalMs = Math.max(0, targetMs - now);
+  const totalSeconds = Math.floor(totalMs / 1000);
+
+  return {
+    days: Math.floor(totalSeconds / 86400),
+    hours: Math.floor((totalSeconds % 86400) / 3600),
+    minutes: Math.floor((totalSeconds % 3600) / 60),
+    seconds: totalSeconds % 60,
+    totalMs,
+  };
+}
+
+export function formatCountdownParts(
+  parts: CountdownParts,
+  showSeconds = false,
+): string {
+  const segments = [
+    `${parts.days}d`,
+    `${String(parts.hours).padStart(2, "0")}h`,
+    `${String(parts.minutes).padStart(2, "0")}m`,
+  ];
+
+  if (showSeconds) {
+    segments.push(`${String(parts.seconds).padStart(2, "0")}s`);
+  }
+
+  return segments.join(" ");
+}
+
+export function getTournamentMilestoneTarget(
+  tournament: TournamentTiming | null | undefined,
+  status: TournamentLifecycleStatus,
+): CountdownTarget {
+  const startMs = toMs(tournament?.tournament_start_date);
+  const stage2Ms = toMs(tournament?.tournament_s2_start_date);
+  const endMs = toMs(tournament?.tournament_end_date);
+
+  if (status === "upcoming") {
+    return { label: "Tournament starts in", targetMs: startMs };
+  }
+
+  if (status === "stage1") {
+    return {
+      label: "Stage 2 starts in",
+      targetMs: stage2Ms ?? endMs,
+    };
+  }
+
+  if (status === "stage2") {
+    return { label: "Voting ends in", targetMs: endMs };
+  }
+
+  return { label: "Tournament finished", targetMs: null };
+}
+
+export function getRoundCountdownTarget(
+  tournament: TournamentTiming | null | undefined,
+  totalRounds: number,
+  activeRound: number,
+): number | null {
+  const stage2Ms = toMs(tournament?.tournament_s2_start_date);
+  const endMs = toMs(tournament?.tournament_end_date);
+
+  if (
+    stage2Ms === null || endMs === null || totalRounds <= 0 || activeRound <= 0
+  ) {
+    return null;
+  }
+
+  const roundDuration = (endMs - stage2Ms) / totalRounds;
+  return stage2Ms + (roundDuration * activeRound);
+}

--- a/app/_utilities/tournamentLifecycle.ts
+++ b/app/_utilities/tournamentLifecycle.ts
@@ -81,6 +81,8 @@ export function formatCountdownParts(
 export function getTournamentMilestoneTarget(
   tournament: TournamentTiming | null | undefined,
   status: TournamentLifecycleStatus,
+  activeRound?: number | null,
+  totalRounds?: number | null,
 ): CountdownTarget {
   const startMs = toMs(tournament?.tournament_start_date);
   const stage2Ms = toMs(tournament?.tournament_s2_start_date);
@@ -98,7 +100,11 @@ export function getTournamentMilestoneTarget(
   }
 
   if (status === "stage2") {
-    return { label: "Voting ends in", targetMs: endMs };
+    if (activeRound && totalRounds && activeRound > 0 && totalRounds > 0) {
+      const roundEnd = getRoundCountdownTarget(tournament, totalRounds, activeRound);
+      return { label: `Round ${activeRound} voting ends`, targetMs: roundEnd };
+    }
+    return { label: "Voting ends", targetMs: endMs };
   }
 
   return { label: "Tournament finished", targetMs: null };
@@ -121,3 +127,19 @@ export function getRoundCountdownTarget(
   const roundDuration = (endMs - stage2Ms) / totalRounds;
   return stage2Ms + (roundDuration * activeRound);
 }
+
+export function formatStatusLabel(
+  status: TournamentLifecycleStatus | string,
+  activeRound?: number | null,
+): string {
+  if (status === "stage1") return "Stage 1";
+  if (status === "stage2") {
+    return activeRound ? `Stage 2 - Round ${activeRound}` : "Stage 2";
+  }
+  if (status === "upcoming") return "Upcoming";
+  if (status === "concluded") return "Concluded";
+  if (status === "terminated") return "Terminated";
+  const str = status as string;
+  return str ? str.charAt(0).toUpperCase() + str.slice(1) : "";
+}
+

--- a/supabase/migrations/20260531_update_tournament_lifecycle.sql
+++ b/supabase/migrations/20260531_update_tournament_lifecycle.sql
@@ -1,0 +1,775 @@
+-- Tournament lifecycle migration
+-- Keeps the existing RPC names but updates them to match the current schema.
+
+create or replace function public.advance_tournament_to_stage1(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_start timestamptz;
+  v_status text;
+  v_cron_name text := 'stage1_start_tournament_' || p_tournament_id;
+begin
+  select tournament_start_date, tournament_status
+  into v_start, v_status
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found then
+    return;
+  end if;
+
+  if exists (select 1 from cron.job where jobname = v_cron_name) then
+    perform cron.unschedule(v_cron_name);
+  end if;
+
+  if v_status in ('terminated', 'concluded', 'stage2') then
+    return;
+  end if;
+
+  if now() < v_start then
+    return;
+  end if;
+
+  update public.tournament
+  set tournament_status = 'stage1',
+      tournament_updated_at = now()
+  where tournament_id = p_tournament_id
+    and tournament_status = 'upcoming';
+end;
+$$;
+
+
+create or replace function public.schedule_stage1_start(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_start timestamptz;
+  v_cron_name text := 'stage1_start_tournament_' || p_tournament_id;
+begin
+  select tournament_start_date
+  into v_start
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found then
+    return;
+  end if;
+
+  if exists (select 1 from cron.job where jobname = v_cron_name) then
+    perform cron.unschedule(v_cron_name);
+  end if;
+
+  if v_start is null or v_start <= now() then
+    return;
+  end if;
+
+  perform cron.schedule(
+    v_cron_name,
+    extract(minute from v_start)::text || ' ' ||
+    extract(hour from v_start)::text || ' ' ||
+    extract(day from v_start)::text || ' ' ||
+    extract(month from v_start)::text || ' *',
+    'SELECT public.advance_tournament_to_stage1(' || p_tournament_id || ');'
+  );
+end;
+$$;
+
+
+create or replace function public.schedule_stage1_end_seeding(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_s2_start timestamptz;
+  v_cron_name text := 'seed_brackets_tournament_' || p_tournament_id;
+begin
+  select tournament_s2_start_date
+  into v_s2_start
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found then
+    return;
+  end if;
+
+  if exists (select 1 from cron.job where jobname = v_cron_name) then
+    perform cron.unschedule(v_cron_name);
+  end if;
+
+  if v_s2_start is null or v_s2_start <= now() then
+    return;
+  end if;
+
+  perform cron.schedule(
+    v_cron_name,
+    extract(minute from v_s2_start)::text || ' ' ||
+    extract(hour from v_s2_start)::text || ' ' ||
+    extract(day from v_s2_start)::text || ' ' ||
+    extract(month from v_s2_start)::text || ' *',
+    'SELECT public.seed_tournament_brackets(' || p_tournament_id || ');'
+  );
+end;
+$$;
+
+
+create or replace function public.schedule_bracket_round_jobs(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+  v_round1_matches int;
+  v_total_rounds int;
+  v_round_duration interval;
+  v_round int;
+  v_job_name text;
+  v_due_at timestamptz;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  select count(*)
+  into v_round1_matches
+  from public.bracket_match bm
+  join public.bracket b on b.bracket_id = bm.bracket_id
+  where b.tournament_id = p_tournament_id
+    and b.bracket_round_number = 1;
+
+  if v_round1_matches is null or v_round1_matches = 0 then
+    return;
+  end if;
+
+  v_total_rounds := greatest(1, ceil(log(2::numeric, (v_round1_matches * 2)::numeric))::int);
+  v_round_duration := (v_tournament.tournament_end_date - v_tournament.tournament_s2_start_date) / v_total_rounds;
+
+  for v_round in 1..v_total_rounds loop
+    v_job_name := 'finalize_bracket_round_' || p_tournament_id || '_r' || v_round;
+    v_due_at := v_tournament.tournament_s2_start_date + (v_round_duration * v_round);
+
+    if exists (select 1 from cron.job where jobname = v_job_name) then
+      perform cron.unschedule(v_job_name);
+    end if;
+
+    if v_due_at <= now() then
+      continue;
+    end if;
+
+    perform cron.schedule(
+      v_job_name,
+      extract(minute from v_due_at)::text || ' ' ||
+      extract(hour from v_due_at)::text || ' ' ||
+      extract(day from v_due_at)::text || ' ' ||
+      extract(month from v_due_at)::text || ' *',
+      'SELECT public.finalize_bracket_round(' || p_tournament_id || ', ' || v_round || ');'
+    );
+  end loop;
+end;
+$$;
+
+
+create or replace function public.seed_tournament_brackets(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+  v_approved_count int;
+  v_seed_count int;
+  v_ranked_subs uuid[];
+  v_existing_round1_bracket_id bigint;
+  v_round1_match_count int;
+  v_idx int;
+  v_slot int;
+  v_sub_a uuid;
+  v_sub_b uuid;
+  v_cron_name text := 'seed_brackets_tournament_' || p_tournament_id;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  if exists (select 1 from cron.job where jobname = v_cron_name) then
+    perform cron.unschedule(v_cron_name);
+  end if;
+
+  if v_tournament.tournament_status = 'stage1' and now() < v_tournament.tournament_s2_start_date then
+    return;
+  end if;
+
+  select count(*)
+  into v_approved_count
+  from public.tournament_submission
+  where tournament_id = p_tournament_id
+    and tournamentsub_status = 'approved';
+
+  if v_approved_count is null or v_approved_count < 2 then
+    return;
+  end if;
+
+  v_seed_count := greatest(2, floor(least(32, v_approved_count) / 2.0)::int);
+  v_seed_count := power(2::numeric, floor(log(2::numeric, v_seed_count::numeric)))::int;
+
+  select array(
+    select ts.tournamentsub_id
+    from public.tournament_submission ts
+    where ts.tournament_id = p_tournament_id
+      and ts.tournamentsub_status = 'approved'
+    order by
+      ts.tournamentsub_likes desc,
+      ts.tournamentsub_updated_at asc,
+      ts.tournamentsub_created_at asc,
+      ts.tournamentsub_id asc
+    limit v_seed_count
+  )
+  into v_ranked_subs;
+
+  if v_ranked_subs is null or array_length(v_ranked_subs, 1) is null or array_length(v_ranked_subs, 1) < 2 then
+    return;
+  end if;
+
+  v_seed_count := array_length(v_ranked_subs, 1);
+
+  select b.bracket_id
+  into v_existing_round1_bracket_id
+  from public.bracket b
+  where b.tournament_id = p_tournament_id
+    and b.bracket_round_number = 1
+  order by b.bracket_id desc
+  limit 1;
+
+  if v_existing_round1_bracket_id is null then
+    insert into public.bracket (tournament_id, bracket_round_number, bracket_status)
+    values (p_tournament_id, 1, 'active')
+    returning bracket_id into v_existing_round1_bracket_id;
+  else
+    update public.bracket
+    set bracket_status = 'active',
+        bracket_updated_at = now()
+    where bracket_id = v_existing_round1_bracket_id;
+  end if;
+
+  select count(*)
+  into v_round1_match_count
+  from public.bracket_match
+  where bracket_id = v_existing_round1_bracket_id;
+
+  if v_round1_match_count = 0 then
+    for v_idx in 0..((v_seed_count / 2) - 1) loop
+      v_sub_a := v_ranked_subs[v_idx * 2 + 1];
+      v_sub_b := v_ranked_subs[v_idx * 2 + 2];
+      v_slot := v_idx + 1;
+
+      insert into public.bracket_match (
+        bracket_id,
+        bmatch_submission_a,
+        bmatch_submission_b,
+        bmatch_status,
+        bmatch_index
+      )
+      values (
+        v_existing_round1_bracket_id,
+        v_sub_a,
+        v_sub_b,
+        'running',
+        jsonb_build_object('round', 1, 'slot', v_slot)
+      );
+    end loop;
+  end if;
+
+  update public.tournament
+  set tournament_status = 'stage2',
+      tournament_updated_at = now()
+  where tournament_id = p_tournament_id
+    and tournament_status not in ('terminated', 'concluded', 'stage2');
+
+  perform public.schedule_bracket_round_jobs(p_tournament_id);
+end;
+$$;
+
+
+create or replace function public.initialize_stage2_brackets(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  perform public.seed_tournament_brackets(p_tournament_id);
+end;
+$$;
+
+
+create or replace function public.finalize_bracket_round(p_tournament_id bigint, p_round bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+  v_bracket_id bigint;
+  v_next_bracket_id bigint;
+  v_match record;
+  v_a_count int;
+  v_b_count int;
+  v_a_reached timestamptz;
+  v_b_reached timestamptz;
+  v_winner_sub_id uuid;
+  v_winners uuid[] := array[]::uuid[];
+  v_round1_matches int;
+  v_total_rounds int;
+  v_round_duration interval;
+  v_round_end timestamptz;
+  v_next_slot int;
+  v_finalize_job_name text := 'finalize_bracket_round_' || p_tournament_id || '_r' || p_round;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  if exists (select 1 from cron.job where jobname = v_finalize_job_name) then
+    perform cron.unschedule(v_finalize_job_name);
+  end if;
+
+  select b.bracket_id
+  into v_bracket_id
+  from public.bracket b
+  where b.tournament_id = p_tournament_id
+    and b.bracket_round_number = p_round
+  order by b.bracket_id desc
+  limit 1;
+
+  if v_bracket_id is null then
+    return;
+  end if;
+
+  select count(*)
+  into v_round1_matches
+  from public.bracket_match bm
+  join public.bracket b on b.bracket_id = bm.bracket_id
+  where b.tournament_id = p_tournament_id
+    and b.bracket_round_number = 1;
+
+  if v_round1_matches is null or v_round1_matches = 0 then
+    return;
+  end if;
+
+  v_total_rounds := greatest(1, ceil(log(2::numeric, (v_round1_matches * 2)::numeric))::int);
+  v_round_duration := (v_tournament.tournament_end_date - v_tournament.tournament_s2_start_date) / v_total_rounds;
+  v_round_end := v_tournament.tournament_s2_start_date + (v_round_duration * p_round);
+
+  if now() < v_round_end then
+    return;
+  end if;
+
+  for v_match in
+    select bm.*
+    from public.bracket_match bm
+    where bm.bracket_id = v_bracket_id
+    order by coalesce((bm.bmatch_index ->> 'slot')::int, 0), bm.bmatch_id
+  loop
+    with vote_events as (
+      select
+        v.tournamentsub_id,
+        coalesce(v.vote_updated_at, v.vote_created_at) as vote_ts,
+        row_number() over (
+          partition by v.tournamentsub_id
+          order by coalesce(v.vote_updated_at, v.vote_created_at), v.user_id
+        ) as rn,
+        count(*) over (partition by v.tournamentsub_id) as total_votes
+      from public.vote v
+      where v.bmatch_id = v_match.bmatch_id
+        and v.tournamentsub_id in (v_match.bmatch_submission_a, v_match.bmatch_submission_b)
+    ),
+    vote_summary as (
+      select
+        tournamentsub_id,
+        count(*)::int as vote_count,
+        max(vote_ts) filter (where rn = total_votes) as reached_at
+      from vote_events
+      group by tournamentsub_id
+    )
+    select
+      coalesce(max(case when tournamentsub_id = v_match.bmatch_submission_a then vote_count end), 0),
+      max(case when tournamentsub_id = v_match.bmatch_submission_a then reached_at end),
+      coalesce(max(case when tournamentsub_id = v_match.bmatch_submission_b then vote_count end), 0),
+      max(case when tournamentsub_id = v_match.bmatch_submission_b then reached_at end)
+    into v_a_count, v_a_reached, v_b_count, v_b_reached
+    from vote_summary;
+
+    if coalesce(v_a_count, 0) > coalesce(v_b_count, 0) then
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    elsif coalesce(v_b_count, 0) > coalesce(v_a_count, 0) then
+      v_winner_sub_id := v_match.bmatch_submission_b;
+    elsif coalesce(v_a_count, 0) = 0 and coalesce(v_b_count, 0) = 0 then
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    elsif coalesce(v_a_reached, 'infinity'::timestamptz) < coalesce(v_b_reached, 'infinity'::timestamptz) then
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    elsif coalesce(v_b_reached, 'infinity'::timestamptz) < coalesce(v_a_reached, 'infinity'::timestamptz) then
+      v_winner_sub_id := v_match.bmatch_submission_b;
+    else
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    end if;
+
+    v_winners := array_append(v_winners, v_winner_sub_id);
+
+    update public.bracket_match
+    set bmatch_status = 'completed',
+        bmatch_updated_at = now()
+    where bmatch_id = v_match.bmatch_id;
+  end loop;
+
+  if array_length(v_winners, 1) is null then
+    return;
+  end if;
+
+  update public.bracket
+  set bracket_status = 'completed',
+      tournamentsub_id = case when array_length(v_winners, 1) = 1 then v_winners[1] else null end,
+      bracket_updated_at = now()
+  where bracket_id = v_bracket_id;
+
+  if array_length(v_winners, 1) = 1 then
+    update public.tournament
+    set tournament_status = 'concluded',
+        tournament_updated_at = now()
+    where tournament_id = p_tournament_id
+      and tournament_status <> 'terminated';
+    return;
+  end if;
+
+  select b.bracket_id
+  into v_next_bracket_id
+  from public.bracket b
+  where b.tournament_id = p_tournament_id
+    and b.bracket_round_number = p_round + 1
+  order by b.bracket_id desc
+  limit 1;
+
+  if v_next_bracket_id is null then
+    insert into public.bracket (
+      tournament_id,
+      bracket_round_number,
+      bracket_status
+    )
+    values (
+      p_tournament_id,
+      p_round + 1,
+      'active'
+    )
+    returning bracket_id into v_next_bracket_id;
+  else
+    update public.bracket
+    set bracket_status = 'active',
+        bracket_updated_at = now()
+    where bracket_id = v_next_bracket_id;
+  end if;
+
+  if not exists (
+    select 1
+    from public.bracket_match
+    where bracket_id = v_next_bracket_id
+  ) then
+    v_next_slot := 1;
+
+    for v_next_slot in 1..(array_length(v_winners, 1) / 2) loop
+      insert into public.bracket_match (
+        bracket_id,
+        bmatch_submission_a,
+        bmatch_submission_b,
+        bmatch_status,
+        bmatch_index
+      )
+      values (
+        v_next_bracket_id,
+        v_winners[(v_next_slot * 2) - 1],
+        v_winners[v_next_slot * 2],
+        'running',
+        jsonb_build_object('round', p_round + 1, 'slot', v_next_slot)
+      );
+    end loop;
+  end if;
+end;
+$$;
+
+
+create or replace function public.advance_bracket_round(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+  v_active_round bigint;
+  v_round1_matches int;
+  v_total_rounds int;
+  v_round_duration interval;
+  v_round_end timestamptz;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  loop
+    select b.bracket_round_number
+    into v_active_round
+    from public.bracket b
+    where b.tournament_id = p_tournament_id
+      and b.bracket_status = 'active'
+    order by b.bracket_round_number desc
+    limit 1;
+
+    exit when v_active_round is null;
+
+    select count(*)
+    into v_round1_matches
+    from public.bracket_match bm
+    join public.bracket b on b.bracket_id = bm.bracket_id
+    where b.tournament_id = p_tournament_id
+      and b.bracket_round_number = 1;
+
+    if v_round1_matches is null or v_round1_matches = 0 then
+      return;
+    end if;
+
+    v_total_rounds := greatest(1, ceil(log(2::numeric, (v_round1_matches * 2)::numeric))::int);
+    v_round_duration := (v_tournament.tournament_end_date - v_tournament.tournament_s2_start_date) / v_total_rounds;
+    v_round_end := v_tournament.tournament_s2_start_date + (v_round_duration * v_active_round);
+
+    exit when now() < v_round_end;
+
+    perform public.finalize_bracket_round(p_tournament_id, v_active_round);
+
+    select tournament_status
+    into v_tournament.tournament_status
+    from public.tournament
+    where tournament_id = p_tournament_id;
+
+    exit when v_tournament.tournament_status in ('terminated', 'concluded');
+  end loop;
+end;
+$$;
+
+
+create or replace function public.advance_stage2_brackets(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  perform public.advance_bracket_round(p_tournament_id);
+end;
+$$;
+
+
+create or replace function public.run_tournament_cron()
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament_id bigint;
+begin
+  update public.tournament
+  set tournament_status = 'stage1',
+      tournament_updated_at = now()
+  where tournament_status = 'upcoming'
+    and now() >= tournament_start_date
+    and tournament_status not in ('terminated', 'concluded');
+
+  update public.tournament
+  set tournament_status = 'stage2',
+      tournament_updated_at = now()
+  where tournament_status = 'stage1'
+    and now() >= tournament_s2_start_date
+    and tournament_status not in ('terminated', 'concluded');
+
+  for v_tournament_id in
+    select t.tournament_id
+    from public.tournament t
+    where t.tournament_status = 'stage2'
+      and not exists (
+        select 1
+        from public.bracket b
+        where b.tournament_id = t.tournament_id
+          and b.bracket_round_number = 1
+      )
+  loop
+    perform public.seed_tournament_brackets(v_tournament_id);
+  end loop;
+
+  for v_tournament_id in
+    select distinct t.tournament_id
+    from public.tournament t
+    join public.bracket b on b.tournament_id = t.tournament_id
+    where t.tournament_status = 'stage2'
+      and b.bracket_status = 'active'
+  loop
+    perform public.advance_bracket_round(v_tournament_id);
+  end loop;
+end;
+$$;
+
+
+create or replace function public.reschedule_tournament_jobs(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_round1_matches int;
+  v_total_rounds int;
+  v_round int;
+  v_finalize_job_name text;
+begin
+  if exists (select 1 from cron.job where jobname = 'stage1_start_tournament_' || p_tournament_id) then
+    perform cron.unschedule('stage1_start_tournament_' || p_tournament_id);
+  end if;
+
+  if exists (select 1 from cron.job where jobname = 'seed_brackets_tournament_' || p_tournament_id) then
+    perform cron.unschedule('seed_brackets_tournament_' || p_tournament_id);
+  end if;
+
+  select count(*)
+  into v_round1_matches
+  from public.bracket_match bm
+  join public.bracket b on b.bracket_id = bm.bracket_id
+  where b.tournament_id = p_tournament_id
+    and b.bracket_round_number = 1;
+
+  if v_round1_matches is not null and v_round1_matches > 0 then
+    v_total_rounds := greatest(1, ceil(log(2::numeric, (v_round1_matches * 2)::numeric))::int);
+
+    for v_round in 1..v_total_rounds loop
+      v_finalize_job_name := 'finalize_bracket_round_' || p_tournament_id || '_r' || v_round;
+
+      if exists (select 1 from cron.job where jobname = v_finalize_job_name) then
+        perform cron.unschedule(v_finalize_job_name);
+      end if;
+    end loop;
+  end if;
+
+  perform public.schedule_stage1_start(p_tournament_id);
+  perform public.schedule_stage1_end_seeding(p_tournament_id);
+
+  perform public.run_tournament_cron();
+end;
+$$;
+
+
+create or replace function public.terminate_tournament(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_total_rounds int;
+  v_round int;
+  v_stage1_name text := 'stage1_start_tournament_' || p_tournament_id;
+  v_seed_name text := 'seed_brackets_tournament_' || p_tournament_id;
+  v_finalize_name text;
+begin
+  update public.tournament
+  set tournament_status = 'terminated',
+      tournament_updated_at = now()
+  where tournament_id = p_tournament_id;
+
+  update public.tournament_submission
+  set tournamentsub_status = 'terminated',
+      tournamentsub_updated_at = now()
+  where tournament_id = p_tournament_id;
+
+  if exists (select 1 from cron.job where jobname = v_stage1_name) then
+    perform cron.unschedule(v_stage1_name);
+  end if;
+
+  if exists (select 1 from cron.job where jobname = v_seed_name) then
+    perform cron.unschedule(v_seed_name);
+  end if;
+
+  select count(*)
+  into v_total_rounds
+  from public.bracket
+  where tournament_id = p_tournament_id;
+
+  if v_total_rounds > 0 then
+    for v_round in 1..v_total_rounds loop
+      v_finalize_name := 'finalize_bracket_round_' || p_tournament_id || '_r' || v_round;
+      if exists (select 1 from cron.job where jobname = v_finalize_name) then
+        perform cron.unschedule(v_finalize_name);
+      end if;
+    end loop;
+  end if;
+
+  update public.bracket
+  set bracket_status = 'completed',
+      bracket_updated_at = now()
+  where tournament_id = p_tournament_id
+    and bracket_status = 'active';
+
+  update public.bracket_match
+  set bmatch_status = 'completed',
+      bmatch_updated_at = now()
+  where bracket_id in (
+    select bracket_id
+    from public.bracket
+    where tournament_id = p_tournament_id
+  )
+    and bmatch_status <> 'completed';
+end;
+$$;
+
+
+create or replace function public.on_tournament_started_trigger()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if pg_trigger_depth() > 1 then
+    return new;
+  end if;
+
+  perform public.run_tournament_cron();
+  return new;
+end;
+$$;

--- a/supabase/migrations/20260601_add_force_to_finalize_bracket_round.sql
+++ b/supabase/migrations/20260601_add_force_to_finalize_bracket_round.sql
@@ -1,0 +1,197 @@
+create or replace function public.finalize_bracket_round(p_tournament_id bigint, p_round bigint, p_force boolean default false)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+  v_bracket_id bigint;
+  v_next_bracket_id bigint;
+  v_match record;
+  v_a_count int;
+  v_b_count int;
+  v_a_reached timestamptz;
+  v_b_reached timestamptz;
+  v_winner_sub_id uuid;
+  v_winners uuid[] := array[]::uuid[];
+  v_round1_matches int;
+  v_total_rounds int;
+  v_round_duration interval;
+  v_round_end timestamptz;
+  v_next_slot int;
+  v_finalize_job_name text := 'finalize_bracket_round_' || p_tournament_id || '_r' || p_round;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  if exists (select 1 from cron.job where jobname = v_finalize_job_name) then
+    perform cron.unschedule(v_finalize_job_name);
+  end if;
+
+  select b.bracket_id
+  into v_bracket_id
+  from public.bracket b
+  where b.tournament_id = p_tournament_id
+    and b.bracket_round_number = p_round
+  order by b.bracket_id desc
+  limit 1;
+
+  if v_bracket_id is null then
+    return;
+  end if;
+
+  select count(*)
+  into v_round1_matches
+  from public.bracket_match bm
+  join public.bracket b on b.bracket_id = bm.bracket_id
+  where b.tournament_id = p_tournament_id
+    and b.bracket_round_number = 1;
+
+  if v_round1_matches is null or v_round1_matches = 0 then
+    return;
+  end if;
+
+  v_total_rounds := greatest(1, ceil(log(2::numeric, (v_round1_matches * 2)::numeric))::int);
+  v_round_duration := (v_tournament.tournament_end_date - v_tournament.tournament_s2_start_date) / v_total_rounds;
+  v_round_end := v_tournament.tournament_s2_start_date + (v_round_duration * p_round);
+
+  if not p_force and now() < v_round_end then
+    return;
+  end if;
+
+  for v_match in
+    select bm.*
+    from public.bracket_match bm
+    where bm.bracket_id = v_bracket_id
+    order by coalesce((bm.bmatch_index ->> 'slot')::int, 0), bm.bmatch_id
+  loop
+    with vote_events as (
+      select
+        v.tournamentsub_id,
+        coalesce(v.vote_updated_at, v.vote_created_at) as vote_ts,
+        row_number() over (
+          partition by v.tournamentsub_id
+          order by coalesce(v.vote_updated_at, v.vote_created_at), v.user_id
+        ) as rn,
+        count(*) over (partition by v.tournamentsub_id) as total_votes
+      from public.vote v
+      where v.bmatch_id = v_match.bmatch_id
+        and v.tournamentsub_id in (v_match.bmatch_submission_a, v_match.bmatch_submission_b)
+    ),
+    vote_summary as (
+      select
+        tournamentsub_id,
+        count(*)::int as vote_count,
+        max(vote_ts) filter (where rn = total_votes) as reached_at
+      from vote_events
+      group by tournamentsub_id
+    )
+    select
+      coalesce(max(case when tournamentsub_id = v_match.bmatch_submission_a then vote_count end), 0),
+      max(case when tournamentsub_id = v_match.bmatch_submission_a then reached_at end),
+      coalesce(max(case when tournamentsub_id = v_match.bmatch_submission_b then vote_count end), 0),
+      max(case when tournamentsub_id = v_match.bmatch_submission_b then reached_at end)
+    into v_a_count, v_a_reached, v_b_count, v_b_reached
+    from vote_summary;
+
+    if coalesce(v_a_count, 0) > coalesce(v_b_count, 0) then
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    elsif coalesce(v_b_count, 0) > coalesce(v_a_count, 0) then
+      v_winner_sub_id := v_match.bmatch_submission_b;
+    elsif coalesce(v_a_count, 0) = 0 and coalesce(v_b_count, 0) = 0 then
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    elsif coalesce(v_a_reached, 'infinity'::timestamptz) < coalesce(v_b_reached, 'infinity'::timestamptz) then
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    elsif coalesce(v_b_reached, 'infinity'::timestamptz) < coalesce(v_a_reached, 'infinity'::timestamptz) then
+      v_winner_sub_id := v_match.bmatch_submission_b;
+    else
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    end if;
+
+    v_winners := array_append(v_winners, v_winner_sub_id);
+
+    update public.bracket_match
+    set bmatch_status = 'completed',
+        bmatch_updated_at = now()
+    where bmatch_id = v_match.bmatch_id;
+  end loop;
+
+  if array_length(v_winners, 1) is null then
+    return;
+  end if;
+
+  update public.bracket
+  set bracket_status = 'completed',
+      tournamentsub_id = case when array_length(v_winners, 1) = 1 then v_winners[1] else null end,
+      bracket_updated_at = now()
+  where bracket_id = v_bracket_id;
+
+  if array_length(v_winners, 1) = 1 then
+    update public.tournament
+    set tournament_status = 'concluded',
+        tournament_updated_at = now()
+    where tournament_id = p_tournament_id
+      and tournament_status <> 'terminated';
+    return;
+  end if;
+
+  select b.bracket_id
+  into v_next_bracket_id
+  from public.bracket b
+  where b.tournament_id = p_tournament_id
+    and b.bracket_round_number = p_round + 1
+  order by b.bracket_id desc
+  limit 1;
+
+  if v_next_bracket_id is null then
+    insert into public.bracket (
+      tournament_id,
+      bracket_round_number,
+      bracket_status
+    )
+    values (
+      p_tournament_id,
+      p_round + 1,
+      'active'
+    )
+    returning bracket_id into v_next_bracket_id;
+  else
+    update public.bracket
+    set bracket_status = 'active',
+        bracket_updated_at = now()
+    where bracket_id = v_next_bracket_id;
+  end if;
+
+  if not exists (
+    select 1
+    from public.bracket_match
+    where bracket_id = v_next_bracket_id
+  ) then
+    v_next_slot := 1;
+
+    for v_next_slot in 1..(array_length(v_winners, 1) / 2) loop
+      insert into public.bracket_match (
+        bracket_id,
+        bmatch_submission_a,
+        bmatch_submission_b,
+        bmatch_status,
+        bmatch_index
+      )
+      values (
+        v_next_bracket_id,
+        v_winners[(v_next_slot * 2) - 1],
+        v_winners[v_next_slot * 2],
+        'running',
+        jsonb_build_object('round', p_round + 1, 'slot', v_next_slot)
+      );
+    end loop;
+  end if;
+end;
+$$;

--- a/supabase/migrations/20260603070023_update_tournament_single_bracket.sql
+++ b/supabase/migrations/20260603070023_update_tournament_single_bracket.sql
@@ -46,7 +46,21 @@ begin
 
   -- 3. Advancing bracket rounds in stage2
   if v_tournament.tournament_status = 'stage2' then
-    perform public.advance_bracket_round(p_tournament_id);
+    -- Check if it is in limbo (stage2 but no brackets exist)
+    if not exists (
+      select 1
+      from public.bracket b
+      where b.tournament_id = p_tournament_id
+    ) then
+      update public.tournament
+      set tournament_status = 'concluded',
+          tournament_updated_at = now()
+      where tournament_id = p_tournament_id;
+      
+      v_tournament.tournament_status := 'concluded';
+    else
+      perform public.advance_bracket_round(p_tournament_id);
+    end if;
   end if;
 end;
 $$;
@@ -87,6 +101,10 @@ begin
     and tournamentsub_status = 'approved';
 
   if v_approved_count is null or v_approved_count = 0 then
+    update public.tournament
+    set tournament_status = 'concluded',
+        tournament_updated_at = now()
+    where tournament_id = p_tournament_id;
     return;
   end if;
 

--- a/supabase/migrations/20260603071009_update_tournament_end_date_on_conclude.sql
+++ b/supabase/migrations/20260603071009_update_tournament_end_date_on_conclude.sql
@@ -1,0 +1,28 @@
+create or replace function public.on_tournament_status_changed_trigger()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if tg_op = 'INSERT' then
+    if new.tournament_status in ('concluded', 'terminated') then
+      new.tournament_end_date := now();
+    end if;
+  elsif tg_op = 'UPDATE' then
+    if new.tournament_status in ('concluded', 'terminated') and old.tournament_status not in ('concluded', 'terminated') then
+      new.tournament_end_date := now();
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+-- Drop trigger if exists
+drop trigger if exists trigger_tournament_status_changed on public.tournament;
+
+-- Create the trigger
+create trigger trigger_tournament_status_changed
+before insert or update on public.tournament
+for each row
+execute function public.on_tournament_status_changed_trigger();

--- a/supabase/migrations/20260603072001_update_tournament_tiebreaker_logic.sql
+++ b/supabase/migrations/20260603072001_update_tournament_tiebreaker_logic.sql
@@ -1,0 +1,328 @@
+create or replace function public.seed_tournament_brackets(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+  v_approved_count int;
+  v_seed_count int;
+  v_ranked_subs uuid[];
+  v_bracket_id bigint;
+  v_round1_match_count int;
+  v_idx int;
+  v_slot int;
+  v_sub_a uuid;
+  v_sub_b uuid;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  -- Count approved submissions
+  select count(*)
+  into v_approved_count
+  from public.tournament_submission
+  where tournament_id = p_tournament_id
+    and tournamentsub_status = 'approved';
+
+  if v_approved_count is null or v_approved_count = 0 then
+    update public.tournament
+    set tournament_status = 'concluded',
+        tournament_updated_at = now()
+    where tournament_id = p_tournament_id;
+    return;
+  end if;
+
+  -- Ensure we have a single bracket row for this tournament
+  select b.bracket_id
+  into v_bracket_id
+  from public.bracket b
+  where b.tournament_id = p_tournament_id
+  order by b.bracket_id desc
+  limit 1;
+
+  if v_bracket_id is null then
+    insert into public.bracket (tournament_id, bracket_round_number, bracket_status)
+    values (p_tournament_id, 1, 'active')
+    returning bracket_id into v_bracket_id;
+  else
+    update public.bracket
+    set bracket_round_number = 1,
+        bracket_status = 'active',
+        tournamentsub_id = null,
+        bracket_updated_at = now()
+    where bracket_id = v_bracket_id;
+  end if;
+
+  -- Special case: 1 approved submission
+  if v_approved_count = 1 then
+    select ts.tournamentsub_id
+    into v_sub_a
+    from public.tournament_submission ts
+    where ts.tournament_id = p_tournament_id
+      and ts.tournamentsub_status = 'approved'
+    limit 1;
+
+    update public.bracket
+    set bracket_status = 'completed',
+        tournamentsub_id = v_sub_a,
+        bracket_round_number = 1,
+        bracket_updated_at = now()
+    where bracket_id = v_bracket_id;
+
+    update public.tournament
+    set tournament_status = 'concluded',
+        tournament_updated_at = now()
+    where tournament_id = p_tournament_id;
+
+    return;
+  end if;
+
+  -- Seeding size logic:
+  -- - For 2-4 submissions, seed 2.
+  -- - For 5+ submissions, greatest power of 2 <= 50% of approved count, capped at 32.
+  v_seed_count := floor(v_approved_count / 2.0)::int;
+  v_seed_count := greatest(2, least(32, v_seed_count));
+  v_seed_count := power(2::numeric, floor(log(2::numeric, v_seed_count::numeric)))::int;
+
+  select array(
+    select ts.tournamentsub_id
+    from public.tournament_submission ts
+    where ts.tournament_id = p_tournament_id
+      and ts.tournamentsub_status = 'approved'
+    order by
+      ts.tournamentsub_likes desc,
+      random()
+    limit v_seed_count
+  )
+  into v_ranked_subs;
+
+  if v_ranked_subs is null or array_length(v_ranked_subs, 1) is null or array_length(v_ranked_subs, 1) < 2 then
+    return;
+  end if;
+
+  v_seed_count := array_length(v_ranked_subs, 1);
+
+  -- Only insert Round 1 matches if they don't already exist for this bracket
+  select count(*)
+  into v_round1_match_count
+  from public.bracket_match
+  where bracket_id = v_bracket_id
+    and (bmatch_index ->> 'round')::int = 1;
+
+  if v_round1_match_count = 0 then
+    for v_idx in 0..((v_seed_count / 2) - 1) loop
+      v_sub_a := v_ranked_subs[v_idx * 2 + 1];
+      v_sub_b := v_ranked_subs[v_idx * 2 + 2];
+      v_slot := v_idx + 1;
+
+      insert into public.bracket_match (
+        bracket_id,
+        bmatch_submission_a,
+        bmatch_submission_b,
+        bmatch_status,
+        bmatch_index
+      )
+      values (
+        v_bracket_id,
+        v_sub_a,
+        v_sub_b,
+        'running',
+        jsonb_build_object('round', 1, 'slot', v_slot)
+      );
+    end loop;
+  end if;
+
+  update public.tournament
+  set tournament_status = 'stage2',
+      tournament_updated_at = now()
+  where tournament_id = p_tournament_id
+    and tournament_status not in ('terminated', 'concluded', 'stage2');
+end;
+$$;
+
+
+create or replace function public.finalize_bracket_round(p_tournament_id bigint, p_round bigint, p_force boolean default false)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+  v_bracket_id bigint;
+  v_match record;
+  v_a_count int;
+  v_b_count int;
+  v_a_reached timestamptz;
+  v_b_reached timestamptz;
+  v_winner_sub_id uuid;
+  v_winners uuid[] := array[]::uuid[];
+  v_round1_matches int;
+  v_total_rounds int;
+  v_round_duration interval;
+  v_round_end timestamptz;
+  v_next_slot int;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  select b.bracket_id
+  into v_bracket_id
+  from public.bracket b
+  where b.tournament_id = p_tournament_id
+  order by b.bracket_id desc
+  limit 1;
+
+  if v_bracket_id is null then
+    return;
+  end if;
+
+  select count(*)
+  into v_round1_matches
+  from public.bracket_match bm
+  where bm.bracket_id = v_bracket_id
+    and (bm.bmatch_index ->> 'round')::int = 1;
+
+  if v_round1_matches is null or v_round1_matches = 0 then
+    return;
+  end if;
+
+  v_total_rounds := greatest(1, ceil(log(2::numeric, (v_round1_matches * 2)::numeric))::int);
+  v_round_duration := (v_tournament.tournament_end_date - v_tournament.tournament_s2_start_date) / v_total_rounds;
+  v_round_end := v_tournament.tournament_s2_start_date + (v_round_duration * p_round);
+
+  if not p_force and now() < v_round_end then
+    return;
+  end if;
+
+  for v_match in
+    select bm.*
+    from public.bracket_match bm
+    where bm.bracket_id = v_bracket_id
+      and (bm.bmatch_index ->> 'round')::int = p_round
+    order by coalesce((bm.bmatch_index ->> 'slot')::int, 0), bm.bmatch_id
+  loop
+    with vote_events as (
+      select
+        v.tournamentsub_id,
+        coalesce(v.vote_updated_at, v.vote_created_at) as vote_ts,
+        row_number() over (
+          partition by v.tournamentsub_id
+          order by coalesce(v.vote_updated_at, v.vote_created_at), v.user_id
+        ) as rn,
+        count(*) over (partition by v.tournamentsub_id) as total_votes
+      from public.vote v
+      where v.bmatch_id = v_match.bmatch_id
+        and v.tournamentsub_id in (v_match.bmatch_submission_a, v_match.bmatch_submission_b)
+    ),
+    vote_summary as (
+      select
+        tournamentsub_id,
+        count(*)::int as vote_count,
+        max(vote_ts) filter (where rn = total_votes) as reached_at
+      from vote_events
+      group by tournamentsub_id
+    )
+    select
+      coalesce(max(case when tournamentsub_id = v_match.bmatch_submission_a then vote_count end), 0),
+      max(case when tournamentsub_id = v_match.bmatch_submission_a then reached_at end),
+      coalesce(max(case when tournamentsub_id = v_match.bmatch_submission_b then vote_count end), 0),
+      max(case when tournamentsub_id = v_match.bmatch_submission_b then reached_at end)
+    into v_a_count, v_a_reached, v_b_count, v_b_reached
+    from vote_summary;
+
+    if coalesce(v_a_count, 0) > coalesce(v_b_count, 0) then
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    elsif coalesce(v_b_count, 0) > coalesce(v_a_count, 0) then
+      v_winner_sub_id := v_match.bmatch_submission_b;
+    elsif coalesce(v_a_count, 0) > 0 then
+      if coalesce(v_a_reached, 'infinity'::timestamptz) < coalesce(v_b_reached, 'infinity'::timestamptz) then
+        v_winner_sub_id := v_match.bmatch_submission_a;
+      elsif coalesce(v_b_reached, 'infinity'::timestamptz) < coalesce(v_a_reached, 'infinity'::timestamptz) then
+        v_winner_sub_id := v_match.bmatch_submission_b;
+      else
+        if random() < 0.5 then
+          v_winner_sub_id := v_match.bmatch_submission_a;
+        else
+          v_winner_sub_id := v_match.bmatch_submission_b;
+        end if;
+      end if;
+    else
+      if random() < 0.5 then
+        v_winner_sub_id := v_match.bmatch_submission_a;
+      else
+        v_winner_sub_id := v_match.bmatch_submission_b;
+      end if;
+    end if;
+
+    v_winners := array_append(v_winners, v_winner_sub_id);
+
+    update public.bracket_match
+    set bmatch_status = 'completed',
+        bmatch_updated_at = now()
+    where bmatch_id = v_match.bmatch_id;
+  end loop;
+
+  if array_length(v_winners, 1) is null then
+    return;
+  end if;
+
+  if array_length(v_winners, 1) = 1 then
+    update public.bracket
+    set bracket_status = 'completed',
+        tournamentsub_id = v_winners[1],
+        bracket_updated_at = now()
+    where bracket_id = v_bracket_id;
+
+    update public.tournament
+    set tournament_status = 'concluded',
+        tournament_updated_at = now()
+    where tournament_id = p_tournament_id
+      and tournament_status <> 'terminated';
+    return;
+  end if;
+
+  update public.bracket
+  set bracket_round_number = p_round + 1,
+      bracket_updated_at = now()
+  where bracket_id = v_bracket_id;
+
+  if not exists (
+    select 1
+    from public.bracket_match
+    where bracket_id = v_bracket_id
+      and (bmatch_index ->> 'round')::int = p_round + 1
+  ) then
+    for v_next_slot in 1..(array_length(v_winners, 1) / 2) loop
+      insert into public.bracket_match (
+        bracket_id,
+        bmatch_submission_a,
+        bmatch_submission_b,
+        bmatch_status,
+        bmatch_index
+      )
+      values (
+        v_bracket_id,
+        v_winners[(v_next_slot * 2) - 1],
+        v_winners[v_next_slot * 2],
+        'running',
+        jsonb_build_object('round', p_round + 1, 'slot', v_next_slot)
+      );
+    end loop;
+  end if;
+end;
+$$;

--- a/supabase/migrations/20260603093652_handle_deleted_book_in_bracket.sql
+++ b/supabase/migrations/20260603093652_handle_deleted_book_in_bracket.sql
@@ -1,0 +1,217 @@
+-- Replace finalize_bracket_round to handle deleted books.
+-- If one side of a match has a deleted submission (or deleted concept), the
+-- opposing side automatically advances regardless of vote counts.
+
+create or replace function public.finalize_bracket_round(p_tournament_id bigint, p_round bigint, p_force boolean default false)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+  v_bracket_id bigint;
+  v_match record;
+  v_a_count int;
+  v_b_count int;
+  v_a_reached timestamptz;
+  v_b_reached timestamptz;
+  v_winner_sub_id uuid;
+  v_winners uuid[] := array[]::uuid[];
+  v_round1_matches int;
+  v_total_rounds int;
+  v_round_duration interval;
+  v_round_end timestamptz;
+  v_next_slot int;
+  v_a_valid boolean;
+  v_b_valid boolean;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  select b.bracket_id
+  into v_bracket_id
+  from public.bracket b
+  where b.tournament_id = p_tournament_id
+  order by b.bracket_id desc
+  limit 1;
+
+  if v_bracket_id is null then
+    return;
+  end if;
+
+  select count(*)
+  into v_round1_matches
+  from public.bracket_match bm
+  where bm.bracket_id = v_bracket_id
+    and (bm.bmatch_index ->> 'round')::int = 1;
+
+  if v_round1_matches is null or v_round1_matches = 0 then
+    return;
+  end if;
+
+  v_total_rounds := greatest(1, ceil(log(2::numeric, (v_round1_matches * 2)::numeric))::int);
+  v_round_duration := (v_tournament.tournament_end_date - v_tournament.tournament_s2_start_date) / v_total_rounds;
+  v_round_end := v_tournament.tournament_s2_start_date + (v_round_duration * p_round);
+
+  if not p_force and now() < v_round_end then
+    return;
+  end if;
+
+  for v_match in
+    select bm.*
+    from public.bracket_match bm
+    where bm.bracket_id = v_bracket_id
+      and (bm.bmatch_index ->> 'round')::int = p_round
+    order by coalesce((bm.bmatch_index ->> 'slot')::int, 0), bm.bmatch_id
+  loop
+    -- Check whether each submission side is still valid (not deleted, concept not deleted)
+    select exists (
+      select 1
+      from public.tournament_submission ts
+      join public.concept c on c.concept_id = ts.concept_id
+      where ts.tournamentsub_id = v_match.bmatch_submission_a
+        and ts.tournamentsub_status <> 'deleted'
+        and ts.tournamentsub_status <> 'terminated'
+        and c.concept_status <> 'deleted'
+    ) into v_a_valid;
+
+    select exists (
+      select 1
+      from public.tournament_submission ts
+      join public.concept c on c.concept_id = ts.concept_id
+      where ts.tournamentsub_id = v_match.bmatch_submission_b
+        and ts.tournamentsub_status <> 'deleted'
+        and ts.tournamentsub_status <> 'terminated'
+        and c.concept_status <> 'deleted'
+    ) into v_b_valid;
+
+    -- Auto-advance if one or both sides are deleted
+    if v_a_valid and not v_b_valid then
+      -- B is deleted → A wins automatically
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    elsif v_b_valid and not v_a_valid then
+      -- A is deleted → B wins automatically
+      v_winner_sub_id := v_match.bmatch_submission_b;
+    elsif not v_a_valid and not v_b_valid then
+      -- Both deleted — pick A arbitrarily (edge case)
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    else
+      -- Both valid — determine winner by votes (original logic)
+      with vote_events as (
+        select
+          v.tournamentsub_id,
+          coalesce(v.vote_updated_at, v.vote_created_at) as vote_ts,
+          row_number() over (
+            partition by v.tournamentsub_id
+            order by coalesce(v.vote_updated_at, v.vote_created_at), v.user_id
+          ) as rn,
+          count(*) over (partition by v.tournamentsub_id) as total_votes
+        from public.vote v
+        where v.bmatch_id = v_match.bmatch_id
+          and v.tournamentsub_id in (v_match.bmatch_submission_a, v_match.bmatch_submission_b)
+      ),
+      vote_summary as (
+        select
+          tournamentsub_id,
+          count(*)::int as vote_count,
+          max(vote_ts) filter (where rn = total_votes) as reached_at
+        from vote_events
+        group by tournamentsub_id
+      )
+      select
+        coalesce(max(case when tournamentsub_id = v_match.bmatch_submission_a then vote_count end), 0),
+        max(case when tournamentsub_id = v_match.bmatch_submission_a then reached_at end),
+        coalesce(max(case when tournamentsub_id = v_match.bmatch_submission_b then vote_count end), 0),
+        max(case when tournamentsub_id = v_match.bmatch_submission_b then reached_at end)
+      into v_a_count, v_a_reached, v_b_count, v_b_reached
+      from vote_summary;
+
+      if coalesce(v_a_count, 0) > coalesce(v_b_count, 0) then
+        v_winner_sub_id := v_match.bmatch_submission_a;
+      elsif coalesce(v_b_count, 0) > coalesce(v_a_count, 0) then
+        v_winner_sub_id := v_match.bmatch_submission_b;
+      elsif coalesce(v_a_count, 0) > 0 then
+        if coalesce(v_a_reached, 'infinity'::timestamptz) < coalesce(v_b_reached, 'infinity'::timestamptz) then
+          v_winner_sub_id := v_match.bmatch_submission_a;
+        elsif coalesce(v_b_reached, 'infinity'::timestamptz) < coalesce(v_a_reached, 'infinity'::timestamptz) then
+          v_winner_sub_id := v_match.bmatch_submission_b;
+        else
+          if random() < 0.5 then
+            v_winner_sub_id := v_match.bmatch_submission_a;
+          else
+            v_winner_sub_id := v_match.bmatch_submission_b;
+          end if;
+        end if;
+      else
+        if random() < 0.5 then
+          v_winner_sub_id := v_match.bmatch_submission_a;
+        else
+          v_winner_sub_id := v_match.bmatch_submission_b;
+        end if;
+      end if;
+    end if;
+
+    v_winners := array_append(v_winners, v_winner_sub_id);
+
+    update public.bracket_match
+    set bmatch_status = 'completed',
+        bmatch_updated_at = now()
+    where bmatch_id = v_match.bmatch_id;
+  end loop;
+
+  if array_length(v_winners, 1) is null then
+    return;
+  end if;
+
+  if array_length(v_winners, 1) = 1 then
+    update public.bracket
+    set bracket_status = 'completed',
+        tournamentsub_id = v_winners[1],
+        bracket_updated_at = now()
+    where bracket_id = v_bracket_id;
+
+    update public.tournament
+    set tournament_status = 'concluded',
+        tournament_updated_at = now()
+    where tournament_id = p_tournament_id
+      and tournament_status <> 'terminated';
+    return;
+  end if;
+
+  update public.bracket
+  set bracket_round_number = p_round + 1,
+      bracket_updated_at = now()
+  where bracket_id = v_bracket_id;
+
+  if not exists (
+    select 1
+    from public.bracket_match
+    where bracket_id = v_bracket_id
+      and (bmatch_index ->> 'round')::int = p_round + 1
+  ) then
+    for v_next_slot in 1..(array_length(v_winners, 1) / 2) loop
+      insert into public.bracket_match (
+        bracket_id,
+        bmatch_submission_a,
+        bmatch_submission_b,
+        bmatch_status,
+        bmatch_index
+      )
+      values (
+        v_bracket_id,
+        v_winners[(v_next_slot * 2) - 1],
+        v_winners[v_next_slot * 2],
+        'running',
+        jsonb_build_object('round', p_round + 1, 'slot', v_next_slot)
+      );
+    end loop;
+  end if;
+end;
+$$;

--- a/supabase/migrations/20260603_update_tournament_single_bracket.sql
+++ b/supabase/migrations/20260603_update_tournament_single_bracket.sql
@@ -519,3 +519,11 @@ begin
   return new;
 end;
 $$;
+
+-- Drop and recreate the trigger to run on both INSERT and UPDATE
+drop trigger if exists trigger_tournament_started on public.tournament;
+
+create trigger trigger_tournament_started
+after insert or update on public.tournament
+for each row
+execute function public.on_tournament_started_trigger();

--- a/supabase/migrations/20260603_update_tournament_single_bracket.sql
+++ b/supabase/migrations/20260603_update_tournament_single_bracket.sql
@@ -1,0 +1,521 @@
+-- Drop pg_cron functions if they exist (clean up database)
+drop function if exists public.schedule_stage1_start(bigint);
+drop function if exists public.schedule_stage1_end_seeding(bigint);
+drop function if exists public.schedule_bracket_round_jobs(bigint);
+drop function if exists public.initialize_stage2_brackets(bigint);
+drop function if exists public.advance_stage2_brackets(bigint);
+drop function if exists public.advance_tournament_to_stage1(bigint);
+
+-- Create or replace lifecycle advancement functions
+create or replace function public.advance_tournament_lifecycle(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  -- 1. Advancing from upcoming to stage1
+  if v_tournament.tournament_status = 'upcoming' and now() >= v_tournament.tournament_start_date then
+    update public.tournament
+    set tournament_status = 'stage1',
+        tournament_updated_at = now()
+    where tournament_id = p_tournament_id;
+    
+    v_tournament.tournament_status := 'stage1';
+  end if;
+
+  -- 2. Advancing from stage1 to stage2 (seeding)
+  if v_tournament.tournament_status = 'stage1' and now() >= v_tournament.tournament_s2_start_date then
+    perform public.seed_tournament_brackets(p_tournament_id);
+    
+    select tournament_status into v_tournament.tournament_status
+    from public.tournament
+    where tournament_id = p_tournament_id;
+  end if;
+
+  -- 3. Advancing bracket rounds in stage2
+  if v_tournament.tournament_status = 'stage2' then
+    perform public.advance_bracket_round(p_tournament_id);
+  end if;
+end;
+$$;
+
+
+create or replace function public.seed_tournament_brackets(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+  v_approved_count int;
+  v_seed_count int;
+  v_ranked_subs uuid[];
+  v_bracket_id bigint;
+  v_round1_match_count int;
+  v_idx int;
+  v_slot int;
+  v_sub_a uuid;
+  v_sub_b uuid;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  -- Count approved submissions
+  select count(*)
+  into v_approved_count
+  from public.tournament_submission
+  where tournament_id = p_tournament_id
+    and tournamentsub_status = 'approved';
+
+  if v_approved_count is null or v_approved_count = 0 then
+    return;
+  end if;
+
+  -- Ensure we have a single bracket row for this tournament
+  select b.bracket_id
+  into v_bracket_id
+  from public.bracket b
+  where b.tournament_id = p_tournament_id
+  order by b.bracket_id desc
+  limit 1;
+
+  if v_bracket_id is null then
+    insert into public.bracket (tournament_id, bracket_round_number, bracket_status)
+    values (p_tournament_id, 1, 'active')
+    returning bracket_id into v_bracket_id;
+  else
+    update public.bracket
+    set bracket_round_number = 1,
+        bracket_status = 'active',
+        tournamentsub_id = null,
+        bracket_updated_at = now()
+    where bracket_id = v_bracket_id;
+  end if;
+
+  -- Special case: 1 approved submission
+  if v_approved_count = 1 then
+    select ts.tournamentsub_id
+    into v_sub_a
+    from public.tournament_submission ts
+    where ts.tournament_id = p_tournament_id
+      and ts.tournamentsub_status = 'approved'
+    limit 1;
+
+    update public.bracket
+    set bracket_status = 'completed',
+        tournamentsub_id = v_sub_a,
+        bracket_round_number = 1,
+        bracket_updated_at = now()
+    where bracket_id = v_bracket_id;
+
+    update public.tournament
+    set tournament_status = 'concluded',
+        tournament_updated_at = now()
+    where tournament_id = p_tournament_id;
+
+    return;
+  end if;
+
+  -- Seeding size logic:
+  -- - For 2-4 submissions, seed 2.
+  -- - For 5+ submissions, greatest power of 2 <= 50% of approved count, capped at 32.
+  v_seed_count := floor(v_approved_count / 2.0)::int;
+  v_seed_count := greatest(2, least(32, v_seed_count));
+  v_seed_count := power(2::numeric, floor(log(2::numeric, v_seed_count::numeric)))::int;
+
+  select array(
+    select ts.tournamentsub_id
+    from public.tournament_submission ts
+    where ts.tournament_id = p_tournament_id
+      and ts.tournamentsub_status = 'approved'
+    order by
+      ts.tournamentsub_likes desc,
+      ts.tournamentsub_updated_at asc,
+      ts.tournamentsub_created_at asc,
+      ts.tournamentsub_id asc
+    limit v_seed_count
+  )
+  into v_ranked_subs;
+
+  if v_ranked_subs is null or array_length(v_ranked_subs, 1) is null or array_length(v_ranked_subs, 1) < 2 then
+    return;
+  end if;
+
+  v_seed_count := array_length(v_ranked_subs, 1);
+
+  -- Only insert Round 1 matches if they don't already exist for this bracket
+  select count(*)
+  into v_round1_match_count
+  from public.bracket_match
+  where bracket_id = v_bracket_id
+    and (bmatch_index ->> 'round')::int = 1;
+
+  if v_round1_match_count = 0 then
+    for v_idx in 0..((v_seed_count / 2) - 1) loop
+      v_sub_a := v_ranked_subs[v_idx * 2 + 1];
+      v_sub_b := v_ranked_subs[v_idx * 2 + 2];
+      v_slot := v_idx + 1;
+
+      insert into public.bracket_match (
+        bracket_id,
+        bmatch_submission_a,
+        bmatch_submission_b,
+        bmatch_status,
+        bmatch_index
+      )
+      values (
+        v_bracket_id,
+        v_sub_a,
+        v_sub_b,
+        'running',
+        jsonb_build_object('round', 1, 'slot', v_slot)
+      );
+    end loop;
+  end if;
+
+  update public.tournament
+  set tournament_status = 'stage2',
+      tournament_updated_at = now()
+  where tournament_id = p_tournament_id
+    and tournament_status not in ('terminated', 'concluded', 'stage2');
+end;
+$$;
+
+
+create or replace function public.finalize_bracket_round(p_tournament_id bigint, p_round bigint, p_force boolean default false)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+  v_bracket_id bigint;
+  v_match record;
+  v_a_count int;
+  v_b_count int;
+  v_a_reached timestamptz;
+  v_b_reached timestamptz;
+  v_winner_sub_id uuid;
+  v_winners uuid[] := array[]::uuid[];
+  v_round1_matches int;
+  v_total_rounds int;
+  v_round_duration interval;
+  v_round_end timestamptz;
+  v_next_slot int;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  select b.bracket_id
+  into v_bracket_id
+  from public.bracket b
+  where b.tournament_id = p_tournament_id
+  order by b.bracket_id desc
+  limit 1;
+
+  if v_bracket_id is null then
+    return;
+  end if;
+
+  select count(*)
+  into v_round1_matches
+  from public.bracket_match bm
+  where bm.bracket_id = v_bracket_id
+    and (bm.bmatch_index ->> 'round')::int = 1;
+
+  if v_round1_matches is null or v_round1_matches = 0 then
+    return;
+  end if;
+
+  v_total_rounds := greatest(1, ceil(log(2::numeric, (v_round1_matches * 2)::numeric))::int);
+  v_round_duration := (v_tournament.tournament_end_date - v_tournament.tournament_s2_start_date) / v_total_rounds;
+  v_round_end := v_tournament.tournament_s2_start_date + (v_round_duration * p_round);
+
+  if not p_force and now() < v_round_end then
+    return;
+  end if;
+
+  for v_match in
+    select bm.*
+    from public.bracket_match bm
+    where bm.bracket_id = v_bracket_id
+      and (bm.bmatch_index ->> 'round')::int = p_round
+    order by coalesce((bm.bmatch_index ->> 'slot')::int, 0), bm.bmatch_id
+  loop
+    with vote_events as (
+      select
+        v.tournamentsub_id,
+        coalesce(v.vote_updated_at, v.vote_created_at) as vote_ts,
+        row_number() over (
+          partition by v.tournamentsub_id
+          order by coalesce(v.vote_updated_at, v.vote_created_at), v.user_id
+        ) as rn,
+        count(*) over (partition by v.tournamentsub_id) as total_votes
+      from public.vote v
+      where v.bmatch_id = v_match.bmatch_id
+        and v.tournamentsub_id in (v_match.bmatch_submission_a, v_match.bmatch_submission_b)
+    ),
+    vote_summary as (
+      select
+        tournamentsub_id,
+        count(*)::int as vote_count,
+        max(vote_ts) filter (where rn = total_votes) as reached_at
+      from vote_events
+      group by tournamentsub_id
+    )
+    select
+      coalesce(max(case when tournamentsub_id = v_match.bmatch_submission_a then vote_count end), 0),
+      max(case when tournamentsub_id = v_match.bmatch_submission_a then reached_at end),
+      coalesce(max(case when tournamentsub_id = v_match.bmatch_submission_b then vote_count end), 0),
+      max(case when tournamentsub_id = v_match.bmatch_submission_b then reached_at end)
+    into v_a_count, v_a_reached, v_b_count, v_b_reached
+    from vote_summary;
+
+    if coalesce(v_a_count, 0) > coalesce(v_b_count, 0) then
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    elsif coalesce(v_b_count, 0) > coalesce(v_a_count, 0) then
+      v_winner_sub_id := v_match.bmatch_submission_b;
+    elsif coalesce(v_a_count, 0) = 0 and coalesce(v_b_count, 0) = 0 then
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    elsif coalesce(v_a_reached, 'infinity'::timestamptz) < coalesce(v_b_reached, 'infinity'::timestamptz) then
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    elsif coalesce(v_b_reached, 'infinity'::timestamptz) < coalesce(v_a_reached, 'infinity'::timestamptz) then
+      v_winner_sub_id := v_match.bmatch_submission_b;
+    else
+      v_winner_sub_id := v_match.bmatch_submission_a;
+    end if;
+
+    v_winners := array_append(v_winners, v_winner_sub_id);
+
+    update public.bracket_match
+    set bmatch_status = 'completed',
+        bmatch_updated_at = now()
+    where bmatch_id = v_match.bmatch_id;
+  end loop;
+
+  if array_length(v_winners, 1) is null then
+    return;
+  end if;
+
+  if array_length(v_winners, 1) = 1 then
+    update public.bracket
+    set bracket_status = 'completed',
+        tournamentsub_id = v_winners[1],
+        bracket_updated_at = now()
+    where bracket_id = v_bracket_id;
+
+    update public.tournament
+    set tournament_status = 'concluded',
+        tournament_updated_at = now()
+    where tournament_id = p_tournament_id
+      and tournament_status <> 'terminated';
+    return;
+  end if;
+
+  update public.bracket
+  set bracket_round_number = p_round + 1,
+      bracket_updated_at = now()
+  where bracket_id = v_bracket_id;
+
+  if not exists (
+    select 1
+    from public.bracket_match
+    where bracket_id = v_bracket_id
+      and (bmatch_index ->> 'round')::int = p_round + 1
+  ) then
+    for v_next_slot in 1..(array_length(v_winners, 1) / 2) loop
+      insert into public.bracket_match (
+        bracket_id,
+        bmatch_submission_a,
+        bmatch_submission_b,
+        bmatch_status,
+        bmatch_index
+      )
+      values (
+        v_bracket_id,
+        v_winners[(v_next_slot * 2) - 1],
+        v_winners[v_next_slot * 2],
+        'running',
+        jsonb_build_object('round', p_round + 1, 'slot', v_next_slot)
+      );
+    end loop;
+  end if;
+end;
+$$;
+
+
+create or replace function public.advance_bracket_round(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament record;
+  v_bracket_id bigint;
+  v_active_round bigint;
+  v_round1_matches int;
+  v_total_rounds int;
+  v_round_duration interval;
+  v_round_end timestamptz;
+begin
+  select *
+  into v_tournament
+  from public.tournament
+  where tournament_id = p_tournament_id;
+
+  if not found or v_tournament.tournament_status in ('terminated', 'concluded') then
+    return;
+  end if;
+
+  select b.bracket_id, b.bracket_round_number
+  into v_bracket_id, v_active_round
+  from public.bracket b
+  where b.tournament_id = p_tournament_id
+    and b.bracket_status = 'active'
+  limit 1;
+
+  if v_bracket_id is null or v_active_round is null then
+    return;
+  end if;
+
+  loop
+    select count(*)
+    into v_round1_matches
+    from public.bracket_match bm
+    where bm.bracket_id = v_bracket_id
+      and (bm.bmatch_index ->> 'round')::int = 1;
+
+    if v_round1_matches is null or v_round1_matches = 0 then
+      return;
+    end if;
+
+    v_total_rounds := greatest(1, ceil(log(2::numeric, (v_round1_matches * 2)::numeric))::int);
+    v_round_duration := (v_tournament.tournament_end_date - v_tournament.tournament_s2_start_date) / v_total_rounds;
+    v_round_end := v_tournament.tournament_s2_start_date + (v_round_duration * v_active_round);
+
+    exit when now() < v_round_end;
+
+    perform public.finalize_bracket_round(p_tournament_id, v_active_round);
+
+    select b.bracket_round_number, b.bracket_status
+    into v_active_round, v_tournament.tournament_status
+    from public.bracket b
+    where b.bracket_id = v_bracket_id;
+
+    exit when v_tournament.tournament_status = 'completed';
+  end loop;
+end;
+$$;
+
+
+create or replace function public.run_tournament_cron()
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_tournament_id bigint;
+begin
+  for v_tournament_id in
+    select t.tournament_id
+    from public.tournament t
+    where t.tournament_status in ('upcoming', 'stage1', 'stage2')
+  loop
+    perform public.advance_tournament_lifecycle(v_tournament_id);
+  end loop;
+end;
+$$;
+
+
+create or replace function public.reschedule_tournament_jobs(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  -- Since pg_cron is not available, we run lifecycle checks immediately
+  perform public.advance_tournament_lifecycle(p_tournament_id);
+end;
+$$;
+
+
+create or replace function public.terminate_tournament(p_tournament_id bigint)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  update public.tournament
+  set tournament_status = 'terminated',
+      tournament_updated_at = now()
+  where tournament_id = p_tournament_id;
+
+  update public.tournament_submission
+  set tournamentsub_status = 'terminated',
+      tournamentsub_updated_at = now()
+  where tournament_id = p_tournament_id;
+
+  update public.bracket
+  set bracket_status = 'completed',
+      bracket_updated_at = now()
+  where tournament_id = p_tournament_id
+    and bracket_status = 'active';
+
+  update public.bracket_match
+  set bmatch_status = 'completed',
+      bmatch_updated_at = now()
+  where bracket_id in (
+    select bracket_id
+    from public.bracket
+    where tournament_id = p_tournament_id
+  )
+    and bmatch_status <> 'completed';
+end;
+$$;
+
+
+create or replace function public.on_tournament_started_trigger()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if pg_trigger_depth() > 1 then
+    return new;
+  end if;
+
+  perform public.advance_tournament_lifecycle(new.tournament_id);
+  return new;
+end;
+$$;


### PR DESCRIPTION
**Bug Fixes**
- Tournament data staleness (cron on page load)
- Votes bleeding across rounds on the 1v1 page
- Book count on dashboard including rejected/deleted submissions

**Tournament Lifecycle**
- Immediate conclusion when stage 2 starts with 0 books
- End date stamped at actual conclusion time
- Fair random tiebreaker logic

**Bracket & Voting UX**
- Round status colour-coding (green/yellow/grey)
- Voting/not-voted dots on bracket cards
- Winner bolded in bracket SVG
- Flip-before-vote requirement
- Cancel/Switch vote buttons on 1v1 page
- Deleted book placeholder (📕) on both bracket and 1v1 pages + auto-advance in SQL

**Capacity & Submissions**
- Accurate capacity bar on dashboard (approved vs pending split)
- Tournament full guard on profile + book builder + admin bulk-add

**Admin Tools**
- Bulk "Add & Approve All Concepts" button

**Profile Page**
- Rejected status display + Re-apply button

**Consistency**
- Season numbering and sort order unified across Dashboard, Past Tournaments, Leaderboard, and Admin pages
- Clickable past tournament cards on dashboard